### PR TITLE
Version 0.0.2

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## Version 0.0.2, Dec 28, 2020
+* Allow using swept area of blades inplace of individual blades for flicker model
+* Allow wind direction and solar data inputs to flicker model
+* Add flicker heatmap weighted by hours shaded as loss option
+* Minor bug fixes and restructuring of flicker functions
+
+## Version 0.0.1, Dec 14, 2020
+* Fixed and updated data in Balance-of-station cost model
+
 ## Version 0.0.0, Dec 2, 2020
 * Official beta release
 * Wind & PV simulations

--- a/examples/flicker.py
+++ b/examples/flicker.py
@@ -32,7 +32,7 @@ hours_to_run = range(3186, 3208)
 FlickerMismatch.diam_mult_nwe = 3
 FlickerMismatch.diam_mult_s = 1
 flicker_single = FlickerMismatch(lat, lon, angles_per_step=1)
-shadow, loss = flicker_single.create_heat_maps_irradiance(hours_to_run)
+shadow, loss = flicker_single.create_heat_maps(hours_to_run, ("poa", "power"))
 plot_flicker(flicker_single, shadow, loss)
 
 # plot grid of turbines
@@ -41,5 +41,5 @@ grid_dy_diams = 3
 grid_degrees = 45
 hours_to_run = [range(3186, 3190), range(3190, 3208)]
 flicker_grid = FlickerMismatchGrid(lat, lon, grid_dx_diams, grid_dy_diams, grid_degrees)
-shadow_grid, loss_grid = flicker_grid.run_parallel(2, hours_to_run)
+shadow_grid, loss_grid = flicker_grid.run_parallel(2, hours_to_run, ("poa", "power"))
 plot_flicker(flicker_grid, shadow_grid, loss_grid)

--- a/examples/flicker.py
+++ b/examples/flicker.py
@@ -39,7 +39,20 @@ plot_flicker(flicker_single, shadow, loss)
 grid_dx_diams = 3
 grid_dy_diams = 3
 grid_degrees = 45
-hours_to_run = [range(3186, 3190), range(3190, 3208)]
+hours_to_run = [range(3186, 3197), range(3197, 3208)]
 flicker_grid = FlickerMismatchGrid(lat, lon, grid_dx_diams, grid_dy_diams, grid_degrees)
-shadow_grid, loss_grid = flicker_grid.run_parallel(2, hours_to_run, ("poa", "power"))
+shadow_grid, loss_grid = flicker_grid.run_parallel(2, ("poa", "power"), hours_to_run)
 plot_flicker(flicker_grid, shadow_grid, loss_grid)
+
+# run flicker calculation of just the blades for a single turbine, using ellipse as swept area, for a whole year
+FlickerMismatch.diam_mult_nwe = 8
+FlickerMismatch.diam_mult_s = 4
+FlickerMismatch.turbine_tower_shadow = False
+FlickerMismatch.steps_per_hour = 4
+flicker_no_tower = FlickerMismatch(lat, lon, angles_per_step=None)
+(flicker_hours_annual, ) = flicker_no_tower.run_parallel(2, ("time", ), [range(0, 200), range(200, 400)])
+axs = flicker_no_tower.plot_on_site(False, False)
+c = plot_contour(flicker_hours_annual, flicker_no_tower, axs)
+plt.colorbar(c)
+plt.title("Ratio Hours under flicker")
+plt.show()

--- a/examples/flicker.py
+++ b/examples/flicker.py
@@ -12,47 +12,64 @@ NREL_API_KEY = os.getenv("NREL_API_KEY")
 set_developer_nrel_gov_key(NREL_API_KEY)  # Set this key manually here if you are not setting it using the .env
 
 
-def plot_flicker(flicker_model, shadow_map, loss_map):
-    axs = flicker_model.plot_on_site(False, False)
-    plot_contour(shadow_map, flicker_model, axs)
-    plt.title("Shadow Weighted by POA")
-    plt.show()
-
-    axs = flicker_model.plot_on_site(False, False)
-    plot_contour(loss_map, flicker_model, axs)
-    plt.title("Flicker")
-    plt.show()
+def plot_flicker(flicker_model, maps, titles):
+    for m, t in zip(maps, titles):
+        axs = flicker_model.plot_on_site(False, False)
+        plot_contour(m, flicker_model, axs)
+        plt.title(t)
+        plt.show()
 
 
 lat = 39.7555
 lon = -105.2211
-hours_to_run = range(3186, 3208)
 
-# plot single turbine
+#
+# Part 1: POA- and Power-based Flicker maps for a Single Turbine
+#
+
+# single turbine on a mini-mesh that is only 3 turbine diameters wide to the north, west and east, and 1 to the south
 FlickerMismatch.diam_mult_nwe = 3
 FlickerMismatch.diam_mult_s = 1
-flicker_single = FlickerMismatch(lat, lon, angles_per_step=1)
-shadow, loss = flicker_single.create_heat_maps(hours_to_run, ("poa", "power"))
-plot_flicker(flicker_single, shadow, loss)
 
-# plot grid of turbines
+# run one blade angles per timestep and create heatmaps of plane-of-array and pv power losses
+flicker_single = FlickerMismatch(lat, lon, angles_per_step=1)
+
+# only run a few hours of the year; normalization will be based on these timesteps only
+hours_to_run = range(3186, 3208)
+shadow, loss = flicker_single.create_heat_maps(hours_to_run, ("poa", "power"))
+plot_flicker(flicker_single, (shadow, loss), ("Flicker weighted by POA Loss", "Flicker weighted by Power Loss"))
+
+#
+# Part 2: POA- and Power-based Flicker maps for a Grid of Turbines with Multiprocessing
+#
+
+# multiple turbines in a 45 degree grid spaced out 3 turbine diameters apart both dimensions
 grid_dx_diams = 3
 grid_dy_diams = 3
 grid_degrees = 45
-hours_to_run = [range(3186, 3197), range(3197, 3208)]
 flicker_grid = FlickerMismatchGrid(lat, lon, grid_dx_diams, grid_dy_diams, grid_degrees)
-shadow_grid, loss_grid = flicker_grid.run_parallel(2, ("poa", "power"), hours_to_run)
-plot_flicker(flicker_grid, shadow_grid, loss_grid)
 
-# run flicker calculation of just the blades for a single turbine, using ellipse as swept area, for a whole year
+# split up the hours into two, one per processor
+hours_to_run = [range(3186, 3197), range(3197, 3208)]
+shadow_grid, loss_grid = flicker_grid.run_parallel(2, ("poa", "power"), hours_to_run)
+plot_flicker(flicker_single, (shadow, loss), ("Flicker weighted by POA Loss", "Flicker weighted by Power Loss"))
+
+#
+# Part 3: Time-based Flicker map for a Single Turbine using Subhourly steps
+#         * This will take ~40 minutes. Refer to the log file to see progress
+#
+
+# switch to full-size mesh and 15-min timesteps
 FlickerMismatch.diam_mult_nwe = 8
 FlickerMismatch.diam_mult_s = 4
-FlickerMismatch.turbine_tower_shadow = False
 FlickerMismatch.steps_per_hour = 4
+
+# run flicker calculation of just the blades
+FlickerMismatch.turbine_tower_shadow = False
+# using ellipse as swept area
 flicker_no_tower = FlickerMismatch(lat, lon, angles_per_step=None)
-(flicker_hours_annual, ) = flicker_no_tower.run_parallel(2, ("time", ), [range(0, 200), range(200, 400)])
-axs = flicker_no_tower.plot_on_site(False, False)
-c = plot_contour(flicker_hours_annual, flicker_no_tower, axs)
-plt.colorbar(c)
-plt.title("Ratio Hours under flicker")
-plt.show()
+
+# to run for whole year, do not provide any intervals-- they will be automatically calculated
+(flicker_hours_annual, ) = flicker_no_tower.run_parallel(6, ("time", ))
+
+plot_flicker(flicker_no_tower, (flicker_hours_annual, ), ("Flicker weighted by Time",))

--- a/examples/optimization/hybrid_opt/hybrid_optimization_problem.py
+++ b/examples/optimization/hybrid_opt/hybrid_optimization_problem.py
@@ -157,7 +157,7 @@ class HybridOptimizationProblem(OptimizationProblem):
             raise NotImplementedError("Flicker look up table for project's lat and lon does not exist.")
         
         bounds = FlickerMismatch.get_turb_site(flicker_diam).bounds
-        _, heatmap_template = FlickerMismatch.setup_heatmap_template(bounds)
+        _, heatmap_template = FlickerMismatch._setup_heatmap_template(bounds)
         turb_x_ind, turb_y_ind = FlickerMismatch.get_turb_pos_indices(heatmap_template)
         
         return flicker_diam, (turb_x_ind, turb_y_ind), flicker_heatmap, heatmap_template[1], heatmap_template[2]

--- a/hybrid/flicker/data/plot_flicker.py
+++ b/hybrid/flicker/data/plot_flicker.py
@@ -15,24 +15,21 @@ def pad_with(vector, pad_width, iaxis, kwargs):
     vector[-pad_width[1]:] = pad_value
 
 
-def plot_contour(map, flicker: Union[FlickerMismatch, FlickerMismatchGrid], axs, levels=500, cmap="viridis"):
+def plot_contour(map, flicker: Union[FlickerMismatch, FlickerMismatchGrid], axs, levels=500, **kwargs):
     if hasattr(flicker, 'center_grid'):
         sx, sy = flicker.center_grid.exterior.xy
         axs.plot(sx, sy)
     coords = flicker.heat_map_template
-    c = axs.contourf(coords[1], coords[2], map, levels)
+    axs.set_aspect("equal")
+    c = axs.contourf(coords[1], coords[2], map, levels, **kwargs)
     return c
 
 
-def plot_tiled(map, flicker: Union[FlickerMismatch, FlickerMismatchGrid], axs, levels=500):
-    # if hasattr(flicker, 'center_grid'):
-    #     sx, sy = flicker.center_grid.exterior.xy
-    #     axs.plot(sx, sy)
+def plot_tiled(map, flicker: Union[FlickerMismatch, FlickerMismatchGrid], axs, **kwargs):
     coords = flicker.heat_map_template
     map_tile = np.tile(map, (3, 3))
-    # x = np.tile(coords[1], 3)
-    # y = np.tile(coords[2], 3)
-    h = axs.imshow(map_tile)
+    h = axs.imshow(map_tile, **kwargs)
+    axs.set_aspect("equal")
     axs.invert_yaxis()
     return h
 

--- a/hybrid/flicker/flicker_mismatch.py
+++ b/hybrid/flicker/flicker_mismatch.py
@@ -2,7 +2,6 @@ from typing import List, Union, Optional
 import multiprocessing as mp
 from pathlib import Path
 import functools
-import pickle
 import copy
 from itertools import product
 import sys
@@ -42,6 +41,8 @@ class FlickerMismatch:
     string_width = module_width
     string_height = modules_per_string * module_height
     periodic = False
+    # shadow properties
+    turbine_tower_shadow = True
     """
     Simulates a wind turbine's flicker over a grid for a given location. The shadow cast by the tower and the three
     blades are calculated for the # of simulation steps: number of blade angles (evenly spaced) per step of the hour. 
@@ -415,7 +416,8 @@ class FlickerMismatch:
                                                              self.angles_per_step,
                                                              self.azi_ang,
                                                              self.elv_ang,
-                                                             self.wind_dir)
+                                                             self.wind_dir,
+                                                             FlickerMismatch.turbine_tower_shadow)
 
         by_poa = by_power = by_time = False
 

--- a/hybrid/flicker/flicker_mismatch.py
+++ b/hybrid/flicker/flicker_mismatch.py
@@ -508,8 +508,9 @@ class FlickerMismatch:
         # aggregate results and renormalize
         heat_maps_to_return = [copy.deepcopy(self.heat_map_template[0]) for n in weight_option]
 
+        subhourly_poa = np.repeat(self.poa, FlickerMismatch.steps_per_hour)
+        total_poa = sum([sum(subhourly_poa[i]) for i in intervals])
         total_steps = sum([len(i) for i in intervals])
-        total_poa = sum([self.poa[i] for i in intervals])
         for r, i in zip(results, intervals):
             for j, hm in enumerate(heat_maps_to_return):
                 if weight_option[j] == 'poa':

--- a/hybrid/flicker/flicker_mismatch_grid.py
+++ b/hybrid/flicker/flicker_mismatch_grid.py
@@ -114,8 +114,8 @@ class FlickerMismatchGrid(FlickerMismatch):
         logger.info("setup_point_maps success")
 
     def _calculate_turbine_shadow(self,
-                                  step: int):
-        return get_turbine_grid_shadow(self.turbine_shadow[step], self.turb_pos)
+                                  ind: int):
+        return get_turbine_grid_shadow(self.turbine_shadow[ind], self.turb_pos)
 
     def plot_on_site(self,
                      plot_points=True,

--- a/hybrid/flicker/flicker_mismatch_grid.py
+++ b/hybrid/flicker/flicker_mismatch_grid.py
@@ -61,8 +61,8 @@ class FlickerMismatchGrid(FlickerMismatch):
         self.grid_turbine_shadow_file = Path(__file__).parent / "data" / str(self.filename_full + "_shd.pkl")
         logger.info("Creating FlickerMismatchModel with filename_full {}".format(self.filename_full))
 
-    def setup_array(self
-                    ) -> None:
+    def _setup_array(self
+                     ) -> None:
         """
         Setup the solar panel array as a Point per panel
         """
@@ -78,7 +78,7 @@ class FlickerMismatchGrid(FlickerMismatch):
         # find the center grid which is symmetrical to all inner grids
         center_grid_coordinates = [(self.turb_pos[t][0], self.turb_pos[t][1]) for t in (5, 6, 10, 9)]
         self.center_grid = Polygon(center_grid_coordinates)
-        self.site_points, self.heat_map_template = self.setup_heatmap_template(self.center_grid.bounds)
+        self.site_points, self.heat_map_template = self._setup_heatmap_template(self.center_grid.bounds)
 
         # where solar strings are
         string_width = module_width
@@ -108,51 +108,14 @@ class FlickerMismatchGrid(FlickerMismatch):
             if array_points.is_empty:
                 continue
 
-            string_points = self.setup_string_points(array_points)
+            string_points = self._setup_string_points(array_points)
 
             self.array_string_points.append(string_points)
         logger.info("setup_point_maps success")
 
-    def create_heat_maps_irradiance(self,
-                                    steps: range
-                                    ) -> tuple:
-        """
-        Create shadow and flicker heat maps for a given range of simulation steps
-        :param steps: which steps to run, must be within range calculated by steps_per_hour x angles_per_step
-        :return: shadow heat map, flicker heat map
-        """
-        proc_id = mp.current_process().name
-        logger.info("Proc {}: Starting heat maps {}".format(proc_id, steps))
-
-        total_poa = sum(self.poa)
-
-        # shadow calculations
-        heat_map_shadow = copy.deepcopy(self.heat_map_template[0])
-
-        # flicker calculations
-        heat_map_flicker = copy.deepcopy(self.heat_map_template[0])
-        progress_size = int(len(steps) / min(10, len(steps)))
-
-        for i, step in enumerate(steps):
-            if i % progress_size == 0:
-                logger.info("Proc {}: Created heat maps for step {}".format(proc_id, int(i / len(steps) * 100)))
-
-            hr = int(step / FlickerMismatch.steps_per_hour)
-            poa_weight = self.poa[hr] / total_poa
-
-            turbine_grid_shadow = get_turbine_grid_shadow(self.turbine_shadow[step], self.turb_pos)
-
-            if not turbine_grid_shadow:
-                continue
-
-            FlickerMismatch.calculate_shading(poa_weight, turbine_grid_shadow, self.site_points, heat_map_shadow)
-
-            FlickerMismatch.calculate_power_loss(self.poa[hr], self.elv_ang[step], turbine_grid_shadow,
-                                                 self.array_string_points, heat_map_flicker)
-
-        logger.info("Proc {}: Finished heat maps".format(proc_id))
-
-        return heat_map_shadow, heat_map_flicker
+    def _calculate_turbine_shadow(self,
+                                  step: int):
+        return get_turbine_grid_shadow(self.turbine_shadow[step], self.turb_pos)
 
     def plot_on_site(self,
                      plot_points=True,
@@ -200,4 +163,4 @@ def create_heat_map_irradiance(grid_dx_diams: float,
     :return: tuple of nd.arrays for shadow and flicker heat maps
     """
     flicker_shading = FlickerMismatchGrid(lat, lon, grid_dx_diams, grid_dy_diams, grid_degrees, angles_per_step=angles)
-    return flicker_shading.run_parallel(procs, steps)
+    return flicker_shading.run_parallel(procs, steps, ("poa", "power"))

--- a/hybrid/flicker/flicker_mismatch_grid.py
+++ b/hybrid/flicker/flicker_mismatch_grid.py
@@ -163,4 +163,4 @@ def create_heat_map_irradiance(grid_dx_diams: float,
     :return: tuple of nd.arrays for shadow and flicker heat maps
     """
     flicker_shading = FlickerMismatchGrid(lat, lon, grid_dx_diams, grid_dy_diams, grid_degrees, angles_per_step=angles)
-    return flicker_shading.run_parallel(procs, steps, ("poa", "power"))
+    return flicker_shading.run_parallel(procs, ("poa", "power"), steps)

--- a/hybrid/flicker/shadow_flicker.py
+++ b/hybrid/flicker/shadow_flicker.py
@@ -397,7 +397,7 @@ def create_pv_string_points(x_coord: float,
     module = Polygon(pts)
 
     xs_string = np.arange(module_width / 2, module_width, module_width)
-    ys_string = np.arange(module_height / 2 + x_coord, y_coord + string_height, module_height)
+    ys_string = np.arange(module_height / 2 + y_coord, y_coord + string_height, module_height)
 
     xxs, yys = np.meshgrid(xs_string, ys_string, sparse=True)
     string_points = MultiPoint(np.transpose([np.tile(xs_string, len(ys_string)),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from setuptools import setup
 
-version = '0.0.1'
+version = '0.0.2'
 
 # copy over packages
 directories = ['hybrid', "tools"]

--- a/tests/hybrid/test_flicker.py
+++ b/tests/hybrid/test_flicker.py
@@ -62,6 +62,20 @@ def test_get_turbine_shadow_polygons_winddir():
     for b in range(4):
         assert shadow.bounds[b] == approx(expected_bounds[b])
 
+    # wind coming from north, widest swept area
+    shadow = get_turbine_shadow_polygons(blade_length=20, blade_angle=0, azi_ang=180, elv_ang=45, wind_dir=0)[0]
+    assert shadow.area == approx(135.2004)
+    expected_bounds = (-10.54126, 0, 20, 67.633)
+    for b in range(4):
+        assert shadow.bounds[b] == approx(expected_bounds[b])
+
+    # wind coming from east, thinnest swept area
+    shadow = get_turbine_shadow_polygons(blade_length=20, blade_angle=0, azi_ang=180, elv_ang=45, wind_dir=90)[0]
+    assert shadow.area == approx(81.1654)
+    expected_bounds = (-0.625, 0, 0.625, 67.633)
+    for b in range(4):
+        assert shadow.bounds[b] == approx(expected_bounds[b])
+
 
 def test_get_turbine_shadow_polygons_2():
     # azimuth 200, elv 45, winddir 0

--- a/tests/hybrid/test_flicker.py
+++ b/tests/hybrid/test_flicker.py
@@ -38,19 +38,19 @@ def test_get_turbine_shadow_polygons():
     azimuth = 180
     shadow = get_turbine_shadow_polygons(blade_length=20, blade_angle=90, azi_ang=azimuth, elv_ang=45, wind_dir=0)[0]
     assert shadow.area == approx(135.6958)
-    expected_bounds = (-17.63300807568878, 3.827021247335479e-17, 17.633008075688775, 70.0)
+    expected_bounds = (-17.63300, 0, 17.63300, 70.0)
     for b in range(4):
         assert shadow.bounds[b] == approx(expected_bounds[b])
 
     shadow = get_turbine_shadow_polygons(blade_length=20, blade_angle=0, azi_ang=azimuth, elv_ang=45, wind_dir=0)[0]
     assert shadow.area == approx(135.2005)
-    expected_bounds = (-10.541265877365282, 3.827021247335479e-17, 20.0, 67.63300807568878)
+    expected_bounds = (-10.54126, 0, 20.0, 67.63300)
     for b in range(4):
         assert shadow.bounds[b] == approx(expected_bounds[b])
 
     shadow = get_turbine_shadow_polygons(blade_length=20, blade_angle=45, azi_ang=azimuth, elv_ang=45, wind_dir=0)[0]
     assert shadow.area == approx(133.7821)
-    expected_bounds = (-19.48027842897044, 3.827021247335479e-17, 14.584077361972545, 64.58407736197255)
+    expected_bounds = (-19.48027, 0, 14.58407, 64.58407)
     for b in range(4):
         assert shadow.bounds[b] == approx(expected_bounds[b])
 
@@ -58,7 +58,7 @@ def test_get_turbine_shadow_polygons():
 def test_get_turbine_shadow_polygons_winddir():
     shadow = get_turbine_shadow_polygons(blade_length=20, blade_angle=0, azi_ang=180, elv_ang=45, wind_dir=45)[0]
     assert shadow.area == approx(123.7373)
-    expected_bounds = (-7.6123336892307565, 3.827021247335479e-17, 14.142135623730951, 67.63300807568878)
+    expected_bounds = (-7.61233, 0, 14.14213, 67.633)
     for b in range(4):
         assert shadow.bounds[b] == approx(expected_bounds[b])
 
@@ -68,25 +68,25 @@ def test_get_turbine_shadow_polygons_2():
     azimuth = 200
     shadow = get_turbine_shadow_polygons(blade_length=20, blade_angle=90, azi_ang=azimuth, elv_ang=45, wind_dir=0)[0]
     assert shadow.area == approx(129.1531)
-    expected_bounds = (-1.9260877865070292, -0.21376258957854294, 29.287699252560525, 65.7784834550136)
+    expected_bounds = (-1.926087, -0.21376258, 29.28769, 65.77848)
     for b in range(4):
         assert shadow.bounds[b] == approx(expected_bounds[b])
 
     shadow = get_turbine_shadow_polygons(blade_length=20, blade_angle=0, azi_ang=azimuth, elv_ang=45, wind_dir=0)[0]
     assert shadow.area == approx(128.6338)
-    expected_bounds = (-0.5873078879911927, -0.21376258957854294, 34.76145159747322, 66.78702271471559)
+    expected_bounds = (-0.5873078, -0.21376258, 34.76145, 66.78702)
     for b in range(4):
         assert shadow.bounds[b] == approx(expected_bounds[b])
 
     shadow = get_turbine_shadow_polygons(blade_length=20, blade_angle=45, azi_ang=azimuth, elv_ang=45, wind_dir=0)[0]
     assert shadow.area == approx(127.2281)
-    expected_bounds = (-0.5873078879911927, -0.21376258957854294, 34.86766417354703, 58.66139314690842)
+    expected_bounds = (-0.5873078, -0.21376258, 34.86766, 58.66139)
     for b in range(4):
         assert shadow.bounds[b] == approx(expected_bounds[b])
 
     shadow = get_turbine_shadow_polygons(blade_length=20, blade_angle=0, azi_ang=azimuth, elv_ang=45, wind_dir=45)[0]
     assert shadow.area == approx(127.4075)
-    expected_bounds = (-0.5873078879911927, -0.21376258957854294, 34.13402195906636, 66.67283985847735)
+    expected_bounds = (-0.5873078, -0.21376258, 34.13402, 66.67283)
     for b in range(4):
         assert shadow.bounds[b] == approx(expected_bounds[b])
 
@@ -94,11 +94,11 @@ def test_get_turbine_shadow_polygons_2():
 def test_get_turbine_shadow_polygons_solstice():
     shadow, shadow_ang = get_turbine_shadow_polygons(35,
                                                      120,
-                                                     azi_ang=275.7824404502053,
-                                                     elv_ang=22.521680787154185,
-                                                     wind_dir=95.78244045020529)
+                                                     azi_ang=275.782440,
+                                                     elv_ang=22.521680,
+                                                     wind_dir=95.78244)
     assert shadow.area == approx(560.1624)
-    expected_bounds = (-0.11019683215840337, -57.175994012818265, 285.3811899455883, 4.062288445548752)
+    expected_bounds = (-0.1101968, -57.17599, 285.38118, 4.062289)
     for b in range(4):
         assert shadow.bounds[b] == approx(expected_bounds[b])
 
@@ -127,3 +127,11 @@ def test_rotated_ellipse():
     # plt.xlim((-2, 2))
     # plt.ylim((-2, 2))
     # plt.show()
+
+
+def test_swept_area():
+    azimuth = 75
+    shadow = get_turbine_shadow_polygons(blade_length=20, blade_angle=45, azi_ang=azimuth, elv_ang=45, wind_dir=0)[0]
+    expected_bounds = (-63.34583, -19.71403, 0.1617619, 0.6037036)
+    for b in range(4):
+        assert shadow.bounds[b] == approx(expected_bounds[b])

--- a/tests/hybrid/test_flicker_mismatch.py
+++ b/tests/hybrid/test_flicker_mismatch.py
@@ -86,6 +86,50 @@ def test_single_turbine_time_weighted():
     # plot_maps((hours_shaded, hours_shaded_p), flicker)
 
 
+def test_single_turbine_time_weighted_no_tower():
+    FlickerMismatch.turbine_tower_shadow = False
+    FlickerMismatch.diam_mult_nwe = 3
+    FlickerMismatch.diam_mult_s = 1
+    flicker = FlickerMismatch(lat, lon, angles_per_step=None)
+    (hours_shaded, ) = flicker.create_heat_maps(range(3183, 3185), ("time",))
+
+    assert(np.max(hours_shaded) == approx(0.5))
+    assert(np.average(hours_shaded) == approx(0.0015781, 1e-4))
+    assert(np.count_nonzero(hours_shaded) == 251)
+
+    # plot_maps((hours_shaded, ), flicker)
+
+
+def test_single_turbine_time_weighted_no_tower_subhourly():
+    FlickerMismatch.turbine_tower_shadow = False
+    FlickerMismatch.diam_mult_nwe = 3
+    FlickerMismatch.diam_mult_s = 1
+    FlickerMismatch.steps_per_hour = 4
+    flicker = FlickerMismatch(lat, lon, angles_per_step=None)
+
+    # need to multiply index by number of steps in an hour
+    (hours_shaded,) = flicker.create_heat_maps(range(3183 * FlickerMismatch.steps_per_hour,
+                                                     3185 * FlickerMismatch.steps_per_hour), ("time",))
+
+    # average is ~4x hourly run
+    assert(np.max(hours_shaded) == approx(0.375))
+    assert(np.average(hours_shaded) == approx(0.0043933, 1e-4))
+    assert(np.count_nonzero(hours_shaded) == 1983)
+
+    FlickerMismatch.steps_per_hour = 4
+    flicker = FlickerMismatch(lat, lon, angles_per_step=None)
+
+    (hours_shaded,) = flicker.create_heat_maps(range(3183 * FlickerMismatch.steps_per_hour,
+                                                     3185 * FlickerMismatch.steps_per_hour), ("time",))
+
+    # plot_maps((hours_shaded, ), flicker)
+
+    # average is very similar to 4-steps run
+    assert(np.max(hours_shaded) == approx(0.375))
+    assert(np.average(hours_shaded) == approx(0.0041826, 1e-4))
+    assert(np.count_nonzero(hours_shaded) == 2942)
+
+
 def test_grid():
     dx = 1
     dy = 2

--- a/tests/hybrid/test_flicker_mismatch.py
+++ b/tests/hybrid/test_flicker_mismatch.py
@@ -10,7 +10,7 @@ def test_single_turbine():
     FlickerMismatch.diam_mult_nwe = 3
     FlickerMismatch.diam_mult_s = 1
     flicker = FlickerMismatch(lat, lon, angles_per_step=1)
-    shadow, loss = flicker.create_heat_maps_irradiance(range(3186, 3200))
+    shadow, loss = flicker.create_heat_maps(range(3186, 3200), ("poa", "power"))
 
     assert(np.max(shadow) == approx(0.00067, 1e-1))
     assert(np.average(shadow) * 1e6 == approx(3.1, 1e-1))
@@ -21,11 +21,39 @@ def test_single_turbine():
 
     axs = flicker.plot_on_site(False, False)
     plot_contour(loss, flicker, axs)
-    plt.title("Flicker Loss\n{}mod/str, periodic {}".
-              format(FlickerMismatchGrid.modules_per_string, FlickerMismatchGrid.periodic))
     # plt.xlim((-30, 30))
     # plt.ylim((40, 100))
     # plt.show()
+
+
+def test_parallel_single():
+    FlickerMismatch.diam_mult_nwe = 3
+    FlickerMismatch.diam_mult_s = 1
+    flicker = FlickerMismatch(lat, lon, angles_per_step=1)
+
+    shadow, loss = flicker.run_parallel(2, (range(3186, 3188), range(3188, 3200)), ("poa", "power"))
+
+    assert(np.max(shadow) == approx(0.00067, 1e-1))
+    assert(np.average(shadow) * 1e6 == approx(3.1, 1e-1))
+    assert(np.count_nonzero(shadow) > 900)
+    assert(np.max(loss) > 0.2)
+    assert(np.average(loss) > 9e-6)
+    assert(np.count_nonzero(loss) == 60)
+
+
+def test_single_turbine_time_weighted():
+    FlickerMismatch.diam_mult_nwe = 3
+    FlickerMismatch.diam_mult_s = 1
+    flicker = FlickerMismatch(lat, lon, angles_per_step=None)
+    (hours_shaded, ) = flicker.create_heat_maps(range(3186, 3208), ("time",))
+
+    axs = flicker.plot_on_site(False, False)
+    c = plot_contour(hours_shaded, flicker, axs, vmin=np.amin(hours_shaded), vmax=np.amax(hours_shaded))
+    # plt.colorbar(c)
+    # plt.show()
+    assert(np.max(hours_shaded) == approx(0.000913242))
+    assert(np.average(hours_shaded) == approx(1.206235e-05))
+    assert(np.count_nonzero(hours_shaded) > 6560)
 
 
 dx = 1
@@ -35,7 +63,7 @@ angle = 0
 
 def test_grid():
     flicker = FlickerMismatchGrid(lat, lon, dx, dy, angle, angles_per_step=3)
-    shadow, loss = flicker.create_heat_maps_irradiance(range(3186, 3200))
+    shadow, loss = flicker.create_heat_maps(range(3186, 3200), ("poa", "power"))
     axs = flicker.plot_on_site()
 
     assert(np.max(shadow) == approx(0.0021, 1e-1))
@@ -45,10 +73,6 @@ def test_grid():
     assert(np.count_nonzero(loss) == approx(2170, 1e-2))
 
     plot_contour(shadow, flicker, axs)
-    plt.title("Flicker Loss\n{}dx, {}dy, {}deg, {}mod/str, periodic {}".
-              format(dx, dx * dy, angle, FlickerMismatchGrid.modules_per_string, FlickerMismatchGrid.periodic))
-    # plt.xlim((-30, 30))
-    # plt.ylim((40, 100))
     # plt.show()
 
 
@@ -56,22 +80,22 @@ def test_parallel_grid():
     flicker = FlickerMismatchGrid(lat, lon, dx, dy, angle)
 
     start = time.time()
-    shadow_s, flicker_map_s = flicker.create_heat_maps_irradiance(range(500, 560))
+    shadow_s, flicker_map_s = flicker.create_heat_maps(range(500, 560), ("poa", "power"))
     print("serial time:", time.time() - start)
 
     start = time.time()
     intervals = (range(500, 530), range(530, 560))
-    shadow_p, flicker_map_p = flicker.run_parallel(2, intervals=intervals)
+    shadow_p, flicker_map_p = flicker.run_parallel(2, intervals, ("poa", "power"))
     print("2 proc time:", time.time() - start)
 
     start = time.time()
     intervals = (range(500, 510), range(510, 520), range(520, 530), range(530, 540), range(540, 550), range(550, 560))
-    shadow_p, flicker_map_p = flicker.run_parallel(6, intervals=intervals)
+    shadow_p, flicker_map_p = flicker.run_parallel(6, intervals, ("poa", "power"))
     print("6 proc time:", time.time() - start)
 
     start = time.time()
     intervals = (range(500, 505), ) * 12
-    shadow_p, flicker_map_p = flicker.run_parallel(12, intervals=intervals)
+    shadow_p, flicker_map_p = flicker.run_parallel(12, intervals, ("poa", "power"))
     print("12 proc time:", time.time() - start)
 
     diff_shadow = shadow_p - shadow_s
@@ -92,4 +116,3 @@ def test_plot():
     axs = flicker.plot_on_site(False, False)
     plot_contour(flicker_heatmap, flicker, axs)
     plot_tiled(flicker_heatmap, flicker, axs)
-    plt.show()


### PR DESCRIPTION
New Release with Flicker model updates:
 - Allow using turbine's swept area (rotated ellipses) instead of individual blades
 - Allow exclusion of turbine tower's shadow from flicker output
 - Wind direction as time series input
 - Weighting of the flicker heat map by time under flicker
 - Allow choice of how to weight the flicker heat map: "poa", "power" and/or "time"
 - Minor restructuring and speed up
 - Bug fixes to normalization and layout definition
 - Test suite additions and added comments