### PR TITLE
Improves verbosity of ValueError when getting developer key fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ solar and storage.
     
     [https://developer.nrel.gov/signup/](https://developer.nrel.gov/signup/)
     
-7. Create the file `.env` in /HOPP and add one line to it, where \<key\> is the NREL API key you obtained:
+7. Create a new file called ".env" in the root directory of this project.
+ 
+8. Edit the ".env" file using your preferred text editor to add a single line containing your NREL_API_KEY in the format:
     ```
     NREL_API_KEY=<key>
     ```

--- a/hybrid/keys.py
+++ b/hybrid/keys.py
@@ -16,7 +16,7 @@ def get_developer_nrel_gov_key():
                          "(`from hybrid.keys import set_developer_nrel_gov_key`) \n"
                          " - or ensure your Developer key is set using the .env file method."
                          " For details on how to do this, "
-                         "please see Section 7 of Readme.md")
+                         "please see Section 7 and 8 of Readme.md")
     return developer_nrel_gov_key
 
 
@@ -25,7 +25,5 @@ def set_nrel_key_dot_env(path=None):
         load_dotenv(path)
     else:
         r = load_dotenv()
-        print(r)
     NREL_API_KEY = os.getenv("NREL_API_KEY")
-    print("API Key: ".format(NREL_API_KEY))
     set_developer_nrel_gov_key(NREL_API_KEY)

--- a/hybrid/keys.py
+++ b/hybrid/keys.py
@@ -1,4 +1,4 @@
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 import os
 
 developer_nrel_gov_key = ""
@@ -12,8 +12,11 @@ def set_developer_nrel_gov_key(key: str):
 def get_developer_nrel_gov_key():
     global developer_nrel_gov_key
     if len(developer_nrel_gov_key) != 40:
-        raise ValueError("Please provide NREL Developer key using `set_developer_nrel_gov_key`. "
-                         "`from hybrid.keys import set_developer_nrel_gov_key`")
+        raise ValueError("Please provide NREL Developer key using `set_developer_nrel_gov_key`"
+                         "(`from hybrid.keys import set_developer_nrel_gov_key`) \n"
+                         " - or ensure your Developer key is set using the .env file method."
+                         " For details on how to do this, "
+                         "please see Section 7 of Readme.md")
     return developer_nrel_gov_key
 
 
@@ -21,6 +24,8 @@ def set_nrel_key_dot_env(path=None):
     if path:
         load_dotenv(path)
     else:
-        load_dotenv()
+        r = load_dotenv()
+        print(r)
     NREL_API_KEY = os.getenv("NREL_API_KEY")
+    print("API Key: ".format(NREL_API_KEY))
     set_developer_nrel_gov_key(NREL_API_KEY)

--- a/hybrid/sites/site_info.py
+++ b/hybrid/sites/site_info.py
@@ -9,6 +9,7 @@ from hybrid.resource import (
     )
 from hybrid.layout.plot_tools import plot_shape
 from hybrid.log import hybrid_logger as logger
+from hybrid.keys import set_nrel_key_dot_env
 
 
 def plot_site(verts, plt_style, labels):
@@ -35,6 +36,7 @@ class SiteInfo:
         self.lon = data['lon']
         if 'year' not in data:
             data['year'] = 2012
+        set_nrel_key_dot_env()
         self.solar_resource = SolarResource(data['lat'], data['lon'], data['year'], filepath=solar_resource_file)
         # TODO: allow hub height to be used as an optimization variable
         self.wind_resource = WindResource(data['lat'], data['lon'], data['year'], wind_turbine_hub_ht=80,


### PR DESCRIPTION
- Updates README.md with additional direction on using .env method
- Adds set_nrel_key_dot_env to site_info.py (optional for this merge)
- Increases level of detail provided in ValueError in get_developer_nrel_gov_key in keys.py