### PR TITLE
Updates to integrate FLORIS v3

### DIFF
--- a/examples/add_custom_module/floris_input.yaml
+++ b/examples/add_custom_module/floris_input.yaml
@@ -1,0 +1,89 @@
+
+name: Gauss
+description: Three turbines using Gauss model
+floris_version: v3.0.0
+
+logging:
+  console:
+    enable: false
+    level: WARNING
+  file:
+    enable: false
+    level: WARNING
+
+solver:
+  type: turbine_grid
+  turbine_grid_points: 1
+
+farm:
+  layout_x:
+  - 0.0
+  - 630.0
+  - 1260.0
+  layout_y:
+  - 0.0
+  - 0.0
+  - 0.0
+  turbine_type:
+  - nrel_5MW
+
+flow_field:
+  air_density: 1.225
+  reference_wind_height: -1 # -1 is code for use the hub height
+  turbulence_intensity: 0.06
+  wind_directions:
+  - 270.0
+  wind_shear: 0.12
+  wind_speeds:
+  - 8.0
+  wind_veer: 0.0
+
+wake:
+  model_strings:
+    combination_model: sosfs
+    deflection_model: gauss
+    turbulence_model: crespo_hernandez
+    velocity_model: gauss
+
+  enable_secondary_steering: false
+  enable_yaw_added_recovery: false
+  enable_transverse_velocities: false
+
+  wake_deflection_parameters:
+    gauss:
+      ad: 0.0
+      alpha: 0.58
+      bd: 0.0
+      beta: 0.077
+      dm: 1.0
+      ka: 0.38
+      kb: 0.004
+    jimenez:
+      ad: 0.0
+      bd: 0.0
+      kd: 0.05
+
+  wake_velocity_parameters:
+    cc:
+      a_s: 0.179367259
+      b_s: 0.0118889215
+      c_s1: 0.0563691592
+      c_s2: 0.13290157
+      a_f: 3.11
+      b_f: -0.68
+      c_f: 2.41
+      alpha_mod: 1.0
+    gauss:
+      alpha: 0.58
+      beta: 0.077
+      ka: 0.38
+      kb: 0.004
+    jensen:
+      we: 0.05
+
+  wake_turbulence_parameters:
+    crespo_hernandez:
+      initial: 0.1
+      constant: 0.5
+      ai: 0.8
+      downstream: -0.32

--- a/examples/add_custom_module/simulate_hybrid_custom_wind_module.py
+++ b/examples/add_custom_module/simulate_hybrid_custom_wind_module.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent.parent.absolute()))
 
-import json
+import yaml
 from pathlib import Path
 
 from hybrid.sites import SiteInfo, flatirons_site
@@ -12,12 +12,11 @@ from hybrid.keys import set_nrel_key_dot_env
 # ADD CUSTOM WIND MODULE
 # download FLORIS at www.github.com/NREL/FLORIS
 # pip install -e floris
-path_to_floris = Path("/Users/dguittet/Projects/HybridSystems/floris")
-with open(path_to_floris / "examples" / "example_input.json", 'r') as f:
-    floris_config = json.load(f)
+with open("floris_input.yaml", 'r') as f:
+    floris_config = yaml.load(f, yaml.SafeLoader)
 
 # properties from floris
-nTurbs = len(floris_config['farm']['properties']['layout_x'])
+nTurbs = len(floris_config['farm']['layout_x'])
 
 # Set API key
 set_nrel_key_dot_env()

--- a/hybrid/add_custom_modules/custom_wind_floris.py
+++ b/hybrid/add_custom_modules/custom_wind_floris.py
@@ -1,14 +1,14 @@
 # tools to add floris to the hybrid simulation class
 import numpy as np
 import matplotlib.pyplot as plt
-import floris.tools as wfct
+from floris.tools import FlorisInterface
 
 
 class Floris:
 
     def __init__(self, config_dict, site, timestep=()):
 
-        self.fi = wfct.floris_interface.FlorisInterface(input_dict=config_dict["floris_config"])
+        self.fi = FlorisInterface(config_dict["floris_config"])
 
         self.site = site
         self.wind_resource_data = self.site.wind_resource.data
@@ -18,7 +18,7 @@ class Floris:
         self.wind_farm_yCoordinates = self.fi.layout_y
         self.nTurbs = len(self.wind_farm_xCoordinates)
         self.turb_rating = config_dict["turbine_rating_kw"]
-        self.wind_turbine_rotor_diameter = self.fi.floris.farm.turbines[0].rotor_diameter
+        self.wind_turbine_rotor_diameter = self.fi.floris.farm.rotor_diameters[0]
         self.system_capacity = self.nTurbs * self.turb_rating
 
         # turbine power curve (array of kW power outputs)
@@ -75,17 +75,12 @@ class Floris:
         power_turbines = np.zeros((self.nTurbs, 8760))
         power_farm = np.zeros(8760)
 
-        for i in range(self.start_idx, self.end_idx):
+        self.fi.reinitialize(wind_speeds=self.speeds[self.start_idx:self.end_idx], wind_directions=self.wind_dirs[self.start_idx:self.end_idx], time_series=True)
+        self.fi.calculate_wake()
 
-            # reinitialize floris with the wind speed and wind direction
-            self.fi.reinitialize_flow_field(wind_speed=self.speeds[i], wind_direction=self.wind_dirs[i])
+        power_turbines[:, self.start_idx:self.end_idx] = self.fi.get_turbine_powers().reshape((self.nTurbs, self.end_idx - self.start_idx))
+        power_farm[self.start_idx:self.end_idx] = self.fi.get_farm_power().reshape((self.end_idx - self.start_idx))
 
-            # Calculate wake
-            self.fi.calculate_wake()
-
-            # outputs
-            power_turbines[:, i] = self.fi.get_turbine_power()
-            power_farm[i] = self.fi.get_farm_power()
 
         self.gen = power_farm / 1000
         self.annual_energy = np.sum(self.gen)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 NREL-PySAM==3.0.0
 Pillow
 Pyomo>=6.1.2
-floris
+floris>=3.0
 future
 global_land_mask
 Cython


### PR DESCRIPTION
This PR updates the custom wind module to integrate FLORIS v3. This vectorizes the wind series calculation and greatly speeds up the use of FLORIS for the wind plant modeling.

This implementation currently uses the farm defined in `floris_input.yaml`. A subsequent PR will include methods that allow the user to modify the wind plant being simulated.