### PR TITLE
Update HOMP cost model

### DIFF
--- a/examples/H2_Analysis/HOMP_cost_model.py
+++ b/examples/H2_Analysis/HOMP_cost_model.py
@@ -1,6 +1,11 @@
+## HOMP cost model calcuations. This file is for reference for the calculation method
+## File does not run b/c it does not have the degradatio and failure hierarchy set up.
+## A running version with degradation and failure incorporated is in run_degradation_failure.py
+
 import json
 from pathlib import Path
 import numpy as np
+import numpy_financial as npf
 
 import matplotlib.pyplot as plt
 from hybrid.sites import SiteInfo, flatirons_site
@@ -10,6 +15,8 @@ from hybrid.keys import set_nrel_key_dot_env
 from examples.H2_Analysis.simple_dispatch import SimpleDispatch
 from examples.H2_Analysis.degradation import Degradation
 from lcoe.lcoe import lcoe as lcoe_calc
+from examples.H2_Analysis.simple_cash_annuals import simple_cash_annuals
+
 
 examples_dir = Path(__file__).resolve().parents[1]
 plot_degradation = True
@@ -23,9 +30,11 @@ wind_size_mw = 50
 interconnection_size_mw = 50        #Required by HybridSimulation() not currently being used for calculations.
 battery_capacity_mw = 20
 battery_capacity_mwh = battery_capacity_mw * 4 
+electrolyzer_capacity_mw = 1000
 useful_life = 30
 load = [40000] * useful_life * 8760
 discount_rate = 0.07
+amortization_interest = 0.03
 
 technologies = {'pv': {
                 'system_capacity_kw': solar_size_mw * 1000
@@ -58,53 +67,57 @@ generation_profile = hybrid_plant.generation_profile
 pv_capex = hybrid_plant.pv.total_installed_cost
 wind_capex = hybrid_plant.wind.total_installed_cost
 battery_capex = hybrid_plant.battery.total_installed_cost
-electro_capex = 86160284            # from PEM electrolysis spreadsheet model
+electro_capex = 460 * electrolyzer_capacity_mw * 1000           # From HOMP table
 total_installed_cost = pv_capex + wind_capex + battery_capex + electro_capex
 
 # Set base O&M costs
 pv_base_om = 23 * solar_size_mw * 1000            # $/kW, accordin to 2022 ATB; includes asset management, insurance products, site security, cleaning, vegetation removal, and component failure
 wind_base_om = 43 * wind_size_mw * 1000           # $/kW, according to 2022 ATB for landbased wind
-battery_base_om = 0.025 * battery_capex     # 2.5% of CAPEX, according to 2022 ATB
-electro_base_om = 0.05 * electro_capex      # According to PEM electrolysis spreadsheet model. Specifically 4796493 for ~86mil capex
+battery_base_om = 0.025 * battery_capex           # 2.5% of CAPEX, according to 2022 ATB
+electro_base_om = 0.05 * electro_capex            # According to PEM electrolysis spreadsheet model. Specifically 4796493 for ~86mil capex
 
 # Set replacement costs
-inverter_replace_cost = 0.25 * 250  # $0.25/kW for string inverters ($0.14/kW for central inverters); largest string inverters are 250kW and 350kW
+inverter_replace_cost = 0.25 * 250                # $0.25/kW for string inverters ($0.14/kW for central inverters); largest string inverters are 250kW and 350kW
 wind_replace_cost = 300000
-battery_replace_cost = 8000         # Battery replacement cost can be $5k-$11k
+battery_replace_cost = 8000                       # Battery replacement cost can be $5k-$11k
 electro_replace_cost = 0.15 * electro_capex
 
 # Run degradation
 hybrid_degradation = Degradation(technologies, False, useful_life, generation_profile, load)
 hybrid_degradation.simulate_degradation()
 
-### Run failure (later) ###
+### Run failure (doesn't occur here; does occur in run_degradation_failure.py) ###
 
 
-# Calculate O&M costs from degradation
-annualized_pv_om = pv_base_om + ((sum(hybrid_degradation.pv_repair)*inverter_replace_cost)/useful_life)    # Estimated PV O&M is $14-16/kW
-print("Total PV O&M /kW: ", annualized_pv_om/(solar_size_mw * 1000))
-annualized_wind_om = wind_base_om + ((sum(hybrid_degradation.wind_repair)*wind_replace_cost)/useful_life)
-print("Total Wind O&M /kW: ", annualized_wind_om/(wind_size_mw * 1000))
-annualized_battery_om = battery_base_om + ((sum(hybrid_degradation.battery_repair)*battery_replace_cost)/useful_life)
-print("Total Battery O&M /kW: ", annualized_battery_om/(battery_capacity_mw * 1000))
-# annualized_electro_om = electro_base_om + (sum(hybrid_degradation.electro_repair)*electro_replace_cost)/useful_life
-annualized_electro_om = electro_base_om + (((useful_life // 7) * electro_replace_cost)/useful_life)
-print("Total Electrolyzer O&M: ", annualized_electro_om)
+# Calculate full cashflows (no grid connection)
+pv_cf_no_replace = simple_cash_annuals(useful_life, useful_life, pv_capex, pv_base_om, amortization_interest)
+wind_cf_no_replace = simple_cash_annuals(useful_life, useful_life, wind_capex, wind_base_om, amortization_interest)
+battery_cf_no_replace = simple_cash_annuals(useful_life, useful_life, battery_capex, battery_base_om, amortization_interest)
+h2_cf_no_replace = simple_cash_annuals(useful_life, useful_life, electro_capex, electro_base_om, amortization_interest)
 
-# # Add O&M costs from failure
-# annualized_pv_om += ((sum(hybrid_failure.pv_fail)*___)/(useful_life*solar_size_mw*1000)
-# annualized_wind_om += ((sum(hybrid_failure.wind_fail)*3000)/(useful_life*wind_size_mw*1000)
-# annualized_battery_om += ((sum(hybrid_failure.battery_fail)*8000)/useful_life
-# annualized_electro_om += ((sum(hybrid_failure.electro_fail)*___)/useful_life
+# Add repalcement cashflows
+# Relevant for integration into runfile; doesn't work in this file b/c failure isn't incorporated
+pv_cf = np.add((hybrid_failure.pv_repair * inverter_replace_cost), pv_cf_no_replace)
+wind_cf = np.add((hybrid_failure.wind_repair * wind_replace_cost), wind_cf_no_replace)
+battery_cf = np.add((hybrid_failure.battery_repair_failure * battery_replace_cost), battery_cf_no_replace)
+electrolyzer_cf = np.add((hybrid_failure.electrolyzer_repair_failure * electro_replace_cost), h2_cf_no_replace)
 
+# Calculate NPVs
+pv_npv = npf.npv(discount_rate, pv_cf)
+wind_npv = npf.npv(discount_rate, wind_cf)
+battery_npv = npf.npv(discount_rate, battery_cf)
+h2_npv = npf.npv(discount_rate, electrolyzer_cf)
+total_npv = pv_npv + wind_npv + battery_npv + h2_npv
 
-# Calculate adjusted financial parameters manually
-print("Lifetime Electricity Generation: ", sum(hybrid_degradation.hybrid_degraded_generation))
-aep = (sum(hybrid_degradation.hybrid_degraded_generation)/useful_life) * 8760                   # Input in kWh
-total_annualized_om = annualized_pv_om + annualized_wind_om + annualized_battery_om + annualized_electro_om
-annual_h2_prod = aep / 55.5          # Based on kWh/kg H2 from PEM electrolysis spreadsheet model
-lcoe_homp = lcoe_calc(aep, total_installed_cost, total_annualized_om, discount_rate, useful_life)
-lcoh_homp = lcoe_calc(annual_h2_prod, total_installed_cost, total_annualized_om, discount_rate, useful_life)
+# Calculate LCOE
+LCOH_cf_method = -total_npv / (H2_Results['hydrogen_annual_output'] * useful_life)                          # Relevant for integration into run file; doesn't work within this file
+LCOE_cf_method = -total_npv / ((sum(hybrid_degradation.hybrid_degraded_generation)/useful_life) * 8760)
 
-print("LCOE: ", lcoe_homp)
-print("LCOH: ", lcoh_homp)
+# Print results
+print("LCOH: ", LCOH_cf_method)
+print("LCOE: ", LCOE_cf_method)
+print("Total NPV: ", total_npv)
+print("PV NPV: ", pv_npv)
+print("Wind NPV: ", wind_npv)
+print("Battery NPV: ", battery_npv)
+print("Electrolyzer NPV: ", h2_npv)


### PR DESCRIPTION
Reference file for HOMP cost calculation methods. Does not run b/c it does not include failure and degradation hierarchy. Cost model that runs alongside degradation and failure classes can be found in run_degradation_failure.py. 