### PR TITLE
Bugfix: correcting PEM costs with Singlitico model

### DIFF
--- a/hopp/hydrogen/electrolysis/PEM_costs_Singlitico_model.py
+++ b/hopp/hydrogen/electrolysis/PEM_costs_Singlitico_model.py
@@ -66,7 +66,7 @@ class PEMCostsSingliticoModel():
             tuple: CapEx and OpEx costs for a single electrolyzer.
         """
         capex = self.calc_capex(P_elec, RC_elec)
-        opex = self.calc_opex(P_elec, RC_elec)
+        opex = self.calc_opex(P_elec, capex)
 
         return capex, opex
 
@@ -174,13 +174,18 @@ class PEMCostsSingliticoModel():
         return opex_elec_eq + opex_elec_neq
 
 if __name__ == "__main__":
+    # setup up PEM for offshore/in-turbine costs
     pem = PEMCostsSingliticoModel(elec_location=1)
 
-    RC_elec = 700 # reference cost of electrolyzer [MUSD/GW]
-    P_elec = 0.1
+    RC_elec = 600 # reference cost of electrolyzer [MUSD/GW]
+    P_elec = 0.000625 # electrolzyer capacity [GW]
 
-    print(pem.calc_capex(P_elec, RC_elec))
-    print(pem.calc_opex(P_elec, RC_elec))
+    # calculate CapEx and OpEx per unit costs
+    capex = pem.calc_capex(P_elec, RC_elec)
+    opex = pem.calc_opex(P_elec, capex)
+
+    print('capex [MUSD/GW]: ', capex / P_elec)
+    print('opex [MUSD/GW]: ', opex / P_elec)
 
     # capex = []
     # capex_norm = []


### PR DESCRIPTION
This bugfix corrects the input given to the OpEx calculation in the Singlitico PEM costs model. The `run` method on the class is setup to replicate the results found in the [supplementary materials](https://www.sciencedirect.com/science/article/pii/S2667095X21000052#ecom0001) of ([Singlitico, 2021](https://www.sciencedirect.com/science/article/pii/S2667095X21000052)).

### Output of the `run` method:
```
capex [MUSD/GW]:  1428.4600132010441
opex [MUSD/GW]:  55.68117749573096
```

### Results from (Singlitico, 2021):
![image](https://user-images.githubusercontent.com/12664940/217649918-b5eeec2c-9683-4b76-97da-d164df4a87f6.png)
[Taken from Singlitico, 2021 [Supplementary Materials](https://www.sciencedirect.com/science/article/pii/S2667095X21000052#ecom0001)]

![image](https://user-images.githubusercontent.com/12664940/217650220-e55683b6-b733-442c-bc93-6eba8412417f.png)
[Taken from Singlitico, 2021 [Supplementary Materials](https://www.sciencedirect.com/science/article/pii/S2667095X21000052#ecom0001)]