### PR TITLE
Fix KML file reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y libglpk-dev glpk-utils coinor-cbc
           python -m pip install --upgrade pip
+          pip install scikit-learn
           pip install -r requirements.txt
       - name: Install package
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ shapely>=1.8.5,<2.0.0
 setuptools
 timezonefinder
 urllib3
+utm

--- a/tests/hybrid/test_layout.py
+++ b/tests/hybrid/test_layout.py
@@ -156,7 +156,8 @@ def test_kml_file_read():
     wind_resource_file = Path(__file__).absolute().parent.parent.parent / "resource_files" / "wind" / "35.2018863_-101.945027_windtoolkit_2012_60min_80m_100m.srw"
     site = SiteInfo(site_data, solar_resource_file=solar_resource_file, wind_resource_file=wind_resource_file)
     site.plot()
-    assert np.array_equal(np.round(site.polygon.bounds), [13568069.0, 180.0, 13568069.0, 180.0])
+    assert np.array_equal(np.round(site.polygon.bounds), [ 681175., 4944970.,  686386., 4949064.])
+    assert site.polygon.area * 3.86102e-7 == pytest.approx(2.3393, abs=0.01) # m2 to mi2
 
 
 def test_kml_file_append():


### PR DESCRIPTION
Add UTM support to KML file reader

SiteInfo reads in the data in the Google Maps KML coordinate projection "EPSG:4326" and converts it to the correct UTM zone projection based on lat and lon. This now results in the correct shape and area.

Next, a PR will be needed to update the KML writer