### PR TITLE
Feature/green steel ammonia

### DIFF
--- a/LCA_single_scenario_ProFAST.py
+++ b/LCA_single_scenario_ProFAST.py
@@ -6,8 +6,10 @@ Created on Fri Dec  2 12:09:20 2022
 """
 import pandas as pd
 import numpy as np
+import os.path
 
 dircambium = 'Examples/H2_Analysis/Cambium_data/StdScen21_MidCase95by2035_hourly_' 
+dircambium= os.path.join(os.path.split(__file__)[0], dircambium)
 
 # grid_connection_scenario = 'hybrid-grid'
 # atb_year = 2020

--- a/hopp_tools_steel.py
+++ b/hopp_tools_steel.py
@@ -1708,7 +1708,7 @@ def steel_LCOS(
         grid_year = 2040
         
     # Read in csv for grid prices
-    grid_prices = pd.read_csv('examples/H2_Analysis/annual_average_retail_prices.csv',index_col = None,header = 0)
+    grid_prices = pd.read_csv(os.path.join(os.path.split(__file__)[0], 'examples/H2_Analysis/annual_average_retail_prices.csv'),index_col = None,header = 0)
     elec_price = grid_prices.loc[grid_prices['Year']==grid_year,site_name].tolist()[0]
 
     #electricity_cost = lcoe - (((policy_option['Wind PTC']) * 100) / 3) # over the whole lifetime 
@@ -1860,7 +1860,7 @@ def levelized_cost_of_ammonia(
         grid_year = 2040
         
     # Read in csv for grid prices
-    grid_prices = pd.read_csv('examples/H2_Analysis/annual_average_retail_prices.csv',index_col = None,header = 0)
+    grid_prices = pd.read_csv(os.path.join(os.path.split(__file__)[0], 'examples/H2_Analysis/annual_average_retail_prices.csv'),index_col = None,header = 0)
     elec_price = grid_prices.loc[grid_prices['Year']==grid_year,site_name].tolist()[0]
     
     
@@ -1999,7 +1999,7 @@ def levelized_cost_of_h2_transmission(
         grid_year = 2040
         
     # Read in csv for grid prices
-    grid_prices = pd.read_csv('examples/H2_Analysis/annual_average_retail_prices.csv',index_col = None,header = 0)
+    grid_prices = pd.read_csv(os.path.join(os.path.split(__file__)[0], 'examples/H2_Analysis/annual_average_retail_prices.csv'),index_col = None,header = 0)
     elec_price = grid_prices.loc[grid_prices['Year']==grid_year,site_name]/1000
 
     h2_transmission_economics_from_profast,h2_transmission_economics_summary,h2_transmission_price_breakdown=\

--- a/run_profast_for_h2_transmission.py
+++ b/run_profast_for_h2_transmission.py
@@ -16,7 +16,9 @@ import pandas as pd
 
 import ProFAST
 
-dir0 = 'examples/H2_Analysis/'
+import os.path
+
+dir0 = os.path.join(os.path.split(__file__)[0], 'examples/H2_Analysis/')
 
 def run_profast_for_h2_transmission(max_hydrogen_production_rate_kg_hr,max_hydrogen_delivery_rate_kg_hr,pipeline_length_km,electrolyzer_capacity_factor,enduse_capacity_factor,before_after_storage,plant_life,elec_price):
 


### PR DESCRIPTION
Change to using installation-relative path specifications, in order to step towards better tool/project separation.

With these, code should still function as previously, but if, e.g., `HOPP/green_steel_ammonia_run_scenarios.py` were run outside of the HOPP directory (and with appropriate adjustments to imports), the tools from `hopp_tools_steel.py` and other helpers would load successfully.