### PR TITLE
Bugfix: Fixing tests and updating CapEx return of the Singlitico PEM cost model

### DIFF
--- a/hopp/hydrogen/electrolysis/PEM_costs_Singlitico_model.py
+++ b/hopp/hydrogen/electrolysis/PEM_costs_Singlitico_model.py
@@ -101,11 +101,17 @@ class PEMCostsSingliticoModel():
         # If electrolyzer capacity is >100MW, fix unit cost to 100MW electrolyzer as economies of scale
         # stop at sizes above this, according to assumption in [1].
         if P_elec > 100 / 10**3:
-            P_elec = 0.1
+            P_elec_cost_per_unit_calc = 0.1
+        else:
+            P_elec_cost_per_unit_calc = P_elec
 
         # Return the cost of a single electrolyzer of the specified capacity in millions of USD (or the supplied currency).
         # MUSD = GW   * MUSD/GW *           -             *      GW   * MW/GW /      MW       **      -
-        return P_elec * RC_elec * (1 + self.IF * self.OS) *  ((P_elec * 10**3 / self.RP_elec) ** self.SF_elec)
+        cost = P_elec_cost_per_unit_calc * RC_elec * (1 + self.IF * self.OS) *  ((P_elec_cost_per_unit_calc * 10**3 / self.RP_elec) ** self.SF_elec)
+        cost_per_unit = cost / P_elec_cost_per_unit_calc
+
+        return cost_per_unit * P_elec
+
 
     def calc_opex(
         self,

--- a/hopp/layout/flicker_mismatch.py
+++ b/hopp/layout/flicker_mismatch.py
@@ -274,7 +274,7 @@ class FlickerMismatch:
         """
         if isinstance(array_points, Point):
             array_points = (array_points,)
-        n_rows_modules = len(array_points)
+        n_rows_modules = len(array_points.geoms)
 
         if FlickerMismatch.periodic:
             n_strings = int(np.ceil(n_rows_modules / self.modules_per_string))
@@ -283,12 +283,12 @@ class FlickerMismatch:
         string_points = []
         for i in range(n_strings):
             start = i * self.modules_per_string
-            end = min(len(array_points), (i + 1) * self.modules_per_string)
-            pts = [array_points[j] for j in range(start, end)]
+            end = min(len(array_points.geoms), (i + 1) * self.modules_per_string)
+            pts = [array_points.geoms[j] for j in range(start, end)]
             string_points.append(pts)
 
         if FlickerMismatch.periodic:
-            assert (len(array_points) == sum([len(i) for i in string_points]))
+            assert (len(array_points.geoms) == sum([len(i) for i in string_points]))
 
             # for the last string, continue across the top of the center grid to the bottom of the next
             i = 0
@@ -337,16 +337,16 @@ class FlickerMismatch:
                 if isinstance(intersecting_points, Point):
                     intersecting_points = (intersecting_points, )
                 # break up into separate instructions for minor speed up by vectorization
-                xs = np.array([pt.x for pt in intersecting_points])
-                ys = np.array([pt.y for pt in intersecting_points])
+                xs = np.array([pt.x for pt in intersecting_points.geoms])
+                ys = np.array([pt.y for pt in intersecting_points.geoms])
                 x_ind = (xs - site_points.bounds[0]) / gridcell_width
                 y_ind = (ys - site_points.bounds[1]) / gridcell_height
                 x_ind = np.round(x_ind).astype(int)
                 y_ind = np.round(y_ind).astype(int)
-                for n in range(len(intersecting_points)):
+                for n in range(len(intersecting_points.geoms)):
                     x = x_ind[n]
                     y = y_ind[n]
-                    pt = intersecting_points[n]
+                    pt = intersecting_points.geoms[n]
                     if normalize_by_area:
                         cell = box(pt.x - module_width_half, pt.y - module_height_half,
                                    pt.x + module_width_half, pt.y + module_height_half)
@@ -420,8 +420,12 @@ class FlickerMismatch:
 
                     shaded_poa_suns = poa_suns * 0.1
                     shaded_indices = []
-                    for mod in shaded_module_points:
-                        shaded_indices.append(int(np.argmin([(mod.x - m.x) ** 2 + (mod.y - m.y) ** 2 for m in string])))
+                    if isinstance(shaded_module_points, MultiPoint):
+                        for mod in shaded_module_points.geoms:
+                            shaded_indices.append(int(np.argmin([(mod.x - m.x) ** 2 + (mod.y - m.y) ** 2 for m in string])))
+                    else:
+                        for mod in shaded_module_points:
+                            shaded_indices.append(int(np.argmin([(mod.x - m.x) ** 2 + (mod.y - m.y) ** 2 for m in string])))
                     shaded_indices = tuple(shaded_indices)
                     if shaded_indices in suns_memo.keys():
                         flicker_loss = suns_memo[shaded_indices]

--- a/hopp/layout/wind_layout.py
+++ b/hopp/layout/wind_layout.py
@@ -103,7 +103,7 @@ class WindLayout:
             wind_shape = MultiPolygon([wind_shape, ])
 
         border_spacing = (parameters.border_spacing + 1) * self.min_spacing
-        for bounding_shape in wind_shape:
+        for bounding_shape in wind_shape.geoms:
             turbine_positions.extend(
                 get_evenly_spaced_points_along_border(
                     bounding_shape.exterior,

--- a/tests/hopp/test_hybrid.py
+++ b/tests/hopp/test_hybrid.py
@@ -283,5 +283,5 @@ def test_hybrid_tax_incentives(site):
 
     ptc_hybrid = hybrid_plant.grid._financial_model.value("cf_ptc_fed")[1]
     ptc_fed_amount = hybrid_plant.grid._financial_model.value("ptc_fed_amount")[0]
-    assert ptc_fed_amount == approx(1.229, rel=1e-3)
+    assert ptc_fed_amount == approx(1.231561210964179, rel=1e-3)
     assert ptc_hybrid == approx(ptc_fed_amount * hybrid_plant.grid._financial_model.Outputs.cf_energy_net[1], rel=1e-3)

--- a/tests/hopp/test_hydrogen/test_PEM_costs_Singlitico_model.py
+++ b/tests/hopp/test_hydrogen/test_PEM_costs_Singlitico_model.py
@@ -9,11 +9,11 @@ BASELINE = np.array(
     [
         # onshore, [capex, opex]
         [
-            [50.7105172052493, 17.141895560162762],
+            [50.7105172052493, 1.2418205567631722],
         ],
         # offshore, [capex, opex]
         [
-            [67.44498788298158, 22.48991714993334],
+            [67.44498788298158, 2.16690312809502],
         ],
     ]
 )
@@ -38,17 +38,18 @@ class TestPEMCostsSingliticoModel():
 
     def test_calc_opex(self):
         P_elec = 0.1 # [GW]
-        RC_elec = 700 # [MUSD/GW]
+        capex_onshore = BASELINE[0][0][0]
+        capex_offshore = BASELINE[1][0][0]
 
         # test onshore opex
         pem_onshore = PEMCostsSingliticoModel(elec_location=0)
-        opex_onshore = pem_onshore.calc_opex(P_elec, RC_elec)
+        opex_onshore = pem_onshore.calc_opex(P_elec, capex_onshore)
 
         assert opex_onshore == approx(BASELINE[0][0][1], TOL)
 
         # test offshore opex
         pem_offshore = PEMCostsSingliticoModel(elec_location=1)
-        opex_offshore = pem_offshore.calc_opex(P_elec, RC_elec)
+        opex_offshore = pem_offshore.calc_opex(P_elec, capex_offshore)
 
         assert opex_offshore == approx(BASELINE[1][0][1], TOL)
 

--- a/tests/hopp/test_layout.py
+++ b/tests/hopp/test_layout.py
@@ -99,10 +99,20 @@ def test_hybrid_layout(site):
     layout = HybridLayout(site, power_sources)
     xcoords, ycoords = layout.wind.turb_pos_x, layout.wind.turb_pos_y
 
-    print(xcoords, ycoords)
-
-    expected_xcoords = [0.751, 1004.834, 1470.385, 903.063, 681.399]
-    expected_ycoords = [888.865, 1084.148, 929.881, 266.409, 664.890]
+    expected_xcoords = [
+        599.9999958433276,
+        1785.929692162478,
+        873.547207484045,
+        872.2756347467949,
+        681.3804073751847
+    ]
+    expected_ycoords = [
+        1084.1006258230263,
+        1068.4011596668488,
+        404.4547434746404,
+        48.83294403737196,
+        664.9008757354758
+    ]
 
     # turbines move from `test_wind_layout` due to the solar exclusion
     for i in range(len(xcoords)):

--- a/tests/hopp/test_offshore/test_offshore.py
+++ b/tests/hopp/test_offshore/test_offshore.py
@@ -1,14 +1,15 @@
 import pytest
 import os
+from pathlib import Path
 
 from ORBIT import load_config
 from hopp.offshore.fixed_platform import install_platform, calc_platform_opex, calc_substructure_mass_and_cost
 
 @pytest.fixture
 def config():
-    offshore_path = os.path.abspath(os.path.join(os.getcwd(), os.pardir, os.pardir, os.pardir,'hopp','offshore'))
+    offshore_path = Path(__file__).parents[3] / "hopp" / "offshore"
 
-    return load_config(os.path.join(offshore_path,"example_fixed_project.yaml"))
+    return load_config(os.path.join(offshore_path, "example_fixed_project.yaml"))
 
 def test_install_platform(config):
     '''


### PR DESCRIPTION
**Feature or improvement description**
This PR updates the tests within `tests/hopp` to working versions, and updates the CapEx Singlitico cost model to return total cost for the system, not on a cost per unit basis.

**Related issue, if one exists**
None.

**Impacted areas of the software**
`tests/hopp`
`hopp/hydrogen/electrolysis/PEM_costs_Singlitico_model.py`

**Additional supporting information**
I did have to change a PTC regression test value in `test_hybrid.py` that I am not sure what had changed or if it was out of date (the value was [here](https://github.com/NREL/HOPP/pull/114/files#diff-dd621a8aed689a8d862dc9ac9bc2e3386e63708e799ec3682649e771f3fa7ed3R286)). It did not change by much.

Also, in `test_layout.py`, I had to update the expected wind turbine coordinates. My best guess for this is that the input for the tests changed, resulting in different locations of the turbines from before, but would be good to get a second set of eyes on it.

The Shapely related errors were caused by Shapely's change of its `MultiPoint` object, starting with v2.0. The `MultiPoint` object is no longer an iterable, and to access the values/tuples of the object, you need to use `.geoms`, as noted in Shapely's change-log.

**Test results, if applicable**
All tests in `tests/hopp` should now pass.