### PR TITLE
PV and Flicker updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        env:
+          SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: True
         run: |
           pip install scikit-learn
           sudo apt-get update && sudo apt-get install -y libglpk-dev glpk-utils coinor-cbc

--- a/hybrid/layout/flicker_mismatch.py
+++ b/hybrid/layout/flicker_mismatch.py
@@ -373,7 +373,8 @@ class FlickerMismatch:
                               gridcell_width: float,
                               gridcell_height: float,
                               xs_min: float,
-                              ys_min: float
+                              ys_min: float,
+                              poa_shading_ratio: float = 0.9
                               ):
         """
         Update the heat map with flicker losses, using an unshaded string as baseline for normalizing
@@ -387,6 +388,7 @@ class FlickerMismatch:
         :param gridcell_height: height of cells in the heat map
         :param xs_min: min of heat map grid's x coordinates
         :param ys_min: min of heat map grid's y coordinates
+        :param poa_shading_ratio: how much of the poa is blocked by the shadow
         """
         poa_suns = poa/1000
         if elv_ang < 0 or poa_suns < 1e-3:
@@ -424,7 +426,7 @@ class FlickerMismatch:
                     else:
                         shaded_module_points = shaded_module_points.geoms
 
-                    shaded_poa_suns = poa_suns * 0.1
+                    shaded_poa_suns = poa_suns * (1 - poa_shading_ratio)
                     shaded_indices = []
                     for mod in shaded_module_points:
                         shaded_indices.append(int(np.argmin([(mod.x - m.x) ** 2 + (mod.y - m.y) ** 2 for m in string])))

--- a/hybrid/layout/pv_design_utils.py
+++ b/hybrid/layout/pv_design_utils.py
@@ -137,7 +137,7 @@ def verify_capacity_from_electrical_parameters(
     :param n_strings: number of strings in array, -
     :param modules_per_string: modules per string, -
     :param module_power: module power at maximum point point at reference conditions, kW
-    :param percent_max_deviation: if calculated system capacity differs from target by this percent or more, raise an exception
+    :param percent_max_deviation: if calculated system capacity differs from target by this percent or more, raise an exception; if None, do not check
 
     :returns: calculated system capacity, kW
     """

--- a/hybrid/layout/pv_design_utils.py
+++ b/hybrid/layout/pv_design_utils.py
@@ -127,6 +127,7 @@ def verify_capacity_from_electrical_parameters(
     n_strings: float,
     modules_per_string: float,
     module_power: float,
+    percent_max_deviation: float = 5
     ) -> float:
     """
     Computes system capacity from specified number of strings, modules per string and module power.
@@ -136,14 +137,15 @@ def verify_capacity_from_electrical_parameters(
     :param n_strings: number of strings in array, -
     :param modules_per_string: modules per string, -
     :param module_power: module power at maximum point point at reference conditions, kW
+    :param percent_max_deviation: if calculated system capacity differs from target by this percent or more, raise an exception
 
     :returns: calculated system capacity, kW
     """
-    PERCENT_MAX_DEVIATION = 5       # [%]
+    percent_max_deviation = 5       # [%]
     calculated_system_capacity = n_strings * modules_per_string * module_power
-    if abs((calculated_system_capacity / system_capacity_target - 1)) * 100 > PERCENT_MAX_DEVIATION:
+    if percent_max_deviation is not None and abs((calculated_system_capacity / system_capacity_target - 1)) * 100 > percent_max_deviation:
         raise Exception(f"The specified system capacity of {system_capacity_target} kW is more than " \
-                        f"{PERCENT_MAX_DEVIATION}% from the value calculated from the specified number " \
+                        f"{percent_max_deviation}% from the value calculated from the specified number " \
                         f"of strings, modules per string and module power ({int(calculated_system_capacity)} kW).")
 
     return calculated_system_capacity

--- a/hybrid/layout/shadow_flicker.py
+++ b/hybrid/layout/shadow_flicker.py
@@ -89,7 +89,8 @@ def get_turbine_shadow_polygons(blade_length: float,
                                 azi_ang: float,
                                 elv_ang: float,
                                 wind_dir,
-                                tower_shadow: bool = True
+                                tower_shadow: bool = True,
+                                tower_height: Optional[float] = None
                                 ) -> Tuple[Union[None, Polygon, MultiPolygon], float]:
     """
     Calculates the (x, y) coordinates of a wind turbine's shadow, which depends on the sun azimuth and elevation.
@@ -112,7 +113,8 @@ def get_turbine_shadow_polygons(blade_length: float,
     # "Shadow analysis of wind turbines for dual use of land for combined wind and solar photovoltaic power generation":
     # the average tower_height=2.5R; average tower_width=R/16; average blade_width=R/16
     blade_width = blade_length / 16
-    tower_height = 2.5 * blade_length
+    if tower_height is None:
+        tower_height = 2.5 * blade_length
     tower_width = blade_width
 
     # get shadow info

--- a/hybrid/resource/elec_prices.py
+++ b/hybrid/resource/elec_prices.py
@@ -43,7 +43,10 @@ class ElectricityPrices(Resource):
     def format_data(self):
         if not os.path.isfile(self.filename):
             raise IOError(f"ElectricityPrices error: {self.filename} does not exist.")
-        self._data = np.loadtxt(self.filename)
+        try:
+            self._data = np.loadtxt(self.filename)
+        except ValueError:
+            self._data = np.loadtxt(self.filename, skiprows=1)
 
     def data(self):
         if not os.path.isfile(self.filename):

--- a/hybrid/sites/site_info.py
+++ b/hybrid/sites/site_info.py
@@ -117,6 +117,7 @@ class SiteInfo:
             raise ValueError("SiteInfo requires lat and lon")
         self.lat = data['lat']
         self.lon = data['lon']
+        self.n_timesteps = None
         if 'year' not in data:
             data['year'] = 2012
         
@@ -125,6 +126,7 @@ class SiteInfo:
 
         if not data['no_solar']:
             self.solar_resource = SolarResource(data['lat'], data['lon'], data['year'], filepath=solar_resource_file)
+            self.n_timesteps = len(self.solar_resource.data['gh']) // 8760 * 8760
 
         if 'no_wind' not in data:
             data['no_wind'] = False
@@ -133,9 +135,13 @@ class SiteInfo:
             # TODO: allow hub height to be used as an optimization variable
             self.wind_resource = WindResource(data['lat'], data['lon'], data['year'], wind_turbine_hub_ht=hub_height,
                                             filepath=wind_resource_file)
+            n_timesteps = len(self.wind_resource.data['data']) // 8760 * 8760
+            if self.n_timesteps is None:
+                self.n_timesteps = n_timesteps
+            elif self.n_timesteps != n_timesteps:
+                raise ValueError(f"Wind resource timesteps of {n_timesteps} different than other resource timesteps of {self.n_timesteps}")
 
         self.elec_prices = ElectricityPrices(data['lat'], data['lon'], data['year'], filepath=grid_resource_file)
-        self.n_timesteps = len(self.solar_resource.data['gh']) // 8760 * 8760
         self.n_periods_per_day = self.n_timesteps // 365  # TODO: Does not handle leap years well
         self.interval = int((60*24)/self.n_periods_per_day)
         self.urdb_label = data['urdb_label'] if 'urdb_label' in data.keys() else None


### PR DESCRIPTION
Fixes
 - don't assume solar resource is provided in site_info
 - allow tower height to be an input into flicker model
 - allow fraction of poa blocked by shadow to be an input
 - allow modifying max acceptable difference between target and calculated system capacity for detailed PV
 - reading of electricity prices

