### PR TITLE
Adding heuristic load following dispatch method and load following ex…

### DIFF
--- a/examples/simulate_hybrid_load_following.py
+++ b/examples/simulate_hybrid_load_following.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+from hopp.simulation.technologies.sites import SiteInfo, flatirons_site
+from hopp.simulation.hybrid_simulation import HybridSimulation
+from hopp.simulation.technologies.dispatch.plot_tools import plot_battery_output, plot_battery_dispatch_error, plot_generation_profile
+from hopp.utilities.keys import set_nrel_key_dot_env
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Set API key
+set_nrel_key_dot_env()
+
+examples_dir = Path(__file__).parent.absolute()
+
+solar_size_mw = 50
+wind_size_mw = 50
+battery_capacity_mw = 20
+interconnection_size_mw = 50
+
+technologies = {
+    'pv': {
+        'system_capacity_kw': solar_size_mw * 1000,
+    },
+    'wind': {
+        'num_turbines': 25,
+        'turbine_rating_kw': int(wind_size_mw * 1000 / 25)
+    },
+    'battery': {
+        'system_capacity_kwh': battery_capacity_mw * 1000,
+        'system_capacity_kw': battery_capacity_mw * 4 * 1000
+    },
+    'grid': {
+        'interconnect_kw': interconnection_size_mw * 1000
+    }
+}
+
+
+
+# Get resource
+lat = flatirons_site['lat']
+lon = flatirons_site['lon']
+prices_file = examples_dir.parent / "resource_files" / "grid" / "pricing-data-2015-IronMtn-002_factors.csv"
+
+desired_schedule = np.ones(8760) * 20
+variation = np.linspace(0, 182.5*6, 8760)
+for i in range(8760):
+    desired_schedule[i] = desired_schedule[i] + np.sin(variation[i])*5
+
+plt.plot(desired_schedule[0:100])
+plt.show()
+dispatch_options = {'battery_dispatch': 'load_following_heuristic'}
+
+site = SiteInfo(flatirons_site,
+                grid_resource_file=prices_file, desired_schedule=desired_schedule)
+# Create base model
+
+hybrid_plant = HybridSimulation(technologies, site, dispatch_options=dispatch_options)
+
+hybrid_plant.pv.dc_degradation = (0,)             # year over year degradation
+hybrid_plant.wind.wake_model = 3                # constant wake loss, layout-independent
+hybrid_plant.wind.value("wake_int_loss", 1)     # percent wake loss
+
+hybrid_plant.pv.system_capacity_kw = solar_size_mw * 1000
+hybrid_plant.wind.system_capacity_by_num_turbines(wind_size_mw * 1000)
+
+# prices_file are unitless dispatch factors, so add $/kwh here
+hybrid_plant.ppa_price = 0.04
+
+# use single year for now, multiple years with battery not implemented yet
+hybrid_plant.simulate(project_life=20)
+
+print("output after losses over gross output",
+      hybrid_plant.wind.value("annual_energy") / hybrid_plant.wind.value("annual_gross_energy"))
+
+# Save the outputs
+annual_energies = hybrid_plant.annual_energies
+npvs = hybrid_plant.net_present_values
+revs = hybrid_plant.total_revenues
+print(annual_energies)
+print(npvs)
+print(revs)
+
+
+file = 'figures/'
+tag = 'simple2_'
+#plot_battery_dispatch_error(hybrid_plant, plot_filename=file+tag+'battery_dispatch_error.png')
+'''
+for d in range(0, 360, 5):
+    plot_battery_output(hybrid_plant, start_day=d, plot_filename=file+tag+'day'+str(d)+'_battery_gen.png')
+    plot_generation_profile(hybrid_plant, start_day=d, plot_filename=file+tag+'day'+str(d)+'_system_gen.png')
+'''
+# plot_battery_dispatch_error(hybrid_plant)
+# plot_battery_output(hybrid_plant)
+plot_generation_profile(hybrid_plant)
+#plot_battery_dispatch_error(hybrid_plant, plot_filename=tag+'battery_dispatch_error.png')

--- a/examples/simulate_hybrid_load_following.py
+++ b/examples/simulate_hybrid_load_following.py
@@ -45,8 +45,7 @@ variation = np.linspace(0, 182.5*6, 8760)
 for i in range(8760):
     desired_schedule[i] = desired_schedule[i] + np.sin(variation[i])*5
 
-plt.plot(desired_schedule[0:100])
-plt.show()
+
 dispatch_options = {'battery_dispatch': 'load_following_heuristic'}
 
 site = SiteInfo(flatirons_site,

--- a/examples/simulate_hybrid_load_following.py
+++ b/examples/simulate_hybrid_load_following.py
@@ -13,7 +13,7 @@ examples_dir = Path(__file__).parent.absolute()
 
 solar_size_mw = 50
 wind_size_mw = 50
-battery_capacity_mw = 20
+battery_capacity_mw = 50
 interconnection_size_mw = 50
 
 technologies = {
@@ -25,8 +25,8 @@ technologies = {
         'turbine_rating_kw': int(wind_size_mw * 1000 / 25)
     },
     'battery': {
-        'system_capacity_kwh': battery_capacity_mw * 1000,
-        'system_capacity_kw': battery_capacity_mw * 4 * 1000
+        'system_capacity_kwh': battery_capacity_mw * 4* 1000,
+        'system_capacity_kw': battery_capacity_mw * 1000
     },
     'grid': {
         'interconnect_kw': interconnection_size_mw * 1000
@@ -45,8 +45,14 @@ variation = np.linspace(0, 182.5*6, 8760)
 for i in range(8760):
     desired_schedule[i] = desired_schedule[i] + np.sin(variation[i])*5
 
+desired_schedule =  8760*[20]
+# variation = np.linspace(0, 182.5*6, 8760)
+# for i in range(8760):
+#     desired_schedule[i] = desired_schedule[i] + np.sin(variation[i])*5
 
-dispatch_options = {'battery_dispatch': 'load_following_heuristic'}
+dispatch_options = {'battery_dispatch': 'load_following_heuristic',
+                     'use_higher_hours': True, 
+                     'higher_hours': {'min_regulation_hours': 4, 'min_regulation_power': 5000}}
 
 site = SiteInfo(flatirons_site,
                 grid_resource_file=prices_file, desired_schedule=desired_schedule)
@@ -65,7 +71,7 @@ hybrid_plant.wind.system_capacity_by_num_turbines(wind_size_mw * 1000)
 hybrid_plant.ppa_price = 0.04
 
 # use single year for now, multiple years with battery not implemented yet
-hybrid_plant.simulate(project_life=20)
+hybrid_plant.simulate(project_life=1)
 
 print("output after losses over gross output",
       hybrid_plant.wind.value("annual_energy") / hybrid_plant.wind.value("annual_gross_energy"))

--- a/hopp/simulation/hybrid_simulation.py
+++ b/hopp/simulation/hybrid_simulation.py
@@ -122,6 +122,9 @@ class HybridSimulation:
         :param dispatch_options: ``dict``,
             (optional) dictionary of dispatch options. For details see
             :class:`hybrid.dispatch.hybrid_dispatch_options.HybridDispatchOptions`
+            (optional nested dictionary) ie: {'higher_hours': {'min_regulation_hours', 'min_regulation_power'}}
+            dictionary with inputs for ERS analysis.  For details see
+            :class:`hybrid.grid.Grid`
 
         :param cost_info: ``dict``,
             (optional) dictionary of cost information. For details see
@@ -654,7 +657,8 @@ class HybridSimulation:
         # Consolidate grid generation by copying over power and storage generation information
         if self.battery:
             self.grid.generation_profile_wo_battery = total_gen_before_battery
-        self.grid.simulate_grid_connection(hybrid_size_kw, total_gen, project_life, lifetime_sim, total_gen_max_feasible_year1)
+        self.grid.simulate_grid_connection(hybrid_size_kw, total_gen, project_life, lifetime_sim,\
+            total_gen_max_feasible_year1,dispatch_options=self.dispatch_builder.options)
         self.grid.hybrid_nominal_capacity = hybrid_nominal_capacity
         self.grid.total_gen_max_feasible_year1 = total_gen_max_feasible_year1
         logger.info(f"Hybrid Peformance Simulation Complete. AEPs are {self.annual_energies}.")

--- a/hopp/simulation/technologies/dispatch/hybrid_dispatch_builder_solver.py
+++ b/hopp/simulation/technologies/dispatch/hybrid_dispatch_builder_solver.py
@@ -511,6 +511,7 @@ class HybridDispatchBuilderSolver:
             self.power_sources['battery'].dispatch.prices = prices
 
         if  'load_following' in self.options.battery_dispatch:
+            # TODO: Look into how to define a system as load following or not in the config file
             required_keys = ['desired_load']
             if self.site.follow_desired_schedule:
                 # Get difference between baseload demand and power generation and control scenario variables

--- a/hopp/simulation/technologies/dispatch/hybrid_dispatch_builder_solver.py
+++ b/hopp/simulation/technologies/dispatch/hybrid_dispatch_builder_solver.py
@@ -510,7 +510,22 @@ class HybridDispatchBuilderSolver:
             prices = self.power_sources['grid'].dispatch.electricity_sell_price
             self.power_sources['battery'].dispatch.prices = prices
 
-        self.power_sources['battery'].dispatch.set_fixed_dispatch(tot_gen, grid_limit)
+        if  'load_following' in self.options.battery_dispatch:
+            required_keys = ['desired_load']
+            if self.site.follow_desired_schedule:
+                # Get difference between baseload demand and power generation and control scenario variables
+                load_value = self.site.desired_schedule
+                load_difference =  [(load_value[x] - tot_gen[x]) for x in range(len(tot_gen))]
+                print('value units test', load_value[0], tot_gen[0], print(len(load_difference)))
+                self.power_sources['battery'].dispatch.load_difference = load_difference
+            else:
+                raise ValueError(type(self).__name__ + " requires the following : desired_schedule")
+            # Adding goal_power for the simple battery heuristic method for power setpoint tracking 
+            goal_power = [load_value]*self.options.n_look_ahead_periods
+            ### Note: the inputs grid_limit and goal_power are in MW ###
+            self.power_sources['battery'].dispatch.set_fixed_dispatch(tot_gen, grid_limit, load_value)
+        else:
+            self.power_sources['battery'].dispatch.set_fixed_dispatch(tot_gen, grid_limit)
 
     @property
     def pyomo_model(self) -> pyomo.ConcreteModel:

--- a/hopp/simulation/technologies/dispatch/hybrid_dispatch_builder_solver.py
+++ b/hopp/simulation/technologies/dispatch/hybrid_dispatch_builder_solver.py
@@ -516,7 +516,6 @@ class HybridDispatchBuilderSolver:
                 # Get difference between baseload demand and power generation and control scenario variables
                 load_value = self.site.desired_schedule
                 load_difference =  [(load_value[x] - tot_gen[x]) for x in range(len(tot_gen))]
-                print('value units test', load_value[0], tot_gen[0], print(len(load_difference)))
                 self.power_sources['battery'].dispatch.load_difference = load_difference
             else:
                 raise ValueError(type(self).__name__ + " requires the following : desired_schedule")

--- a/hopp/simulation/technologies/dispatch/hybrid_dispatch_options.py
+++ b/hopp/simulation/technologies/dispatch/hybrid_dispatch_options.py
@@ -3,7 +3,7 @@ from hopp.simulation.technologies.dispatch.power_storage.simple_battery_dispatch
 from hopp.simulation.technologies.dispatch.power_storage.simple_battery_dispatch import SimpleBatteryDispatch
 from hopp.simulation.technologies.dispatch.power_storage.linear_voltage_nonconvex_battery_dispatch import NonConvexLinearVoltageBatteryDispatch
 from hopp.simulation.technologies.dispatch.power_storage.linear_voltage_convex_battery_dispatch import ConvexLinearVoltageBatteryDispatch
-
+from hopp.simulation.technologies.dispatch.power_storage.heuristic_load_following_dispatch import HeuristicLoadFollowingDispatch
 
 class HybridDispatchOptions:
     """
@@ -23,7 +23,7 @@ class HybridDispatchOptions:
                     options: ('glpk', 'cbc')
                 'solver_options': dict, Dispatch solver options
                 'battery_dispatch': str (default='simple'), sets the battery dispatch model to use for dispatch
-                    options: ('simple', 'one_cycle_heuristic', 'heuristic', 'non_convex_LV', 'convex_LV'),
+                    options: ('simple', 'one_cycle_heuristic', 'heuristic', 'non_convex_LV', 'convex_LV', 'load_following_heuristic'),
                 'grid_charging': bool (default=True), can the battery charge from the grid,
                 'pv_charging_only': bool (default=False), whether restricted to only charge from PV (ITC qualification)
                 'include_lifecycle_count': bool (default=True), should battery lifecycle counting be included,
@@ -80,7 +80,8 @@ class HybridDispatchOptions:
             'heuristic': SimpleBatteryDispatchHeuristic,
             'simple': SimpleBatteryDispatch,
             'non_convex_LV': NonConvexLinearVoltageBatteryDispatch,
-            'convex_LV': ConvexLinearVoltageBatteryDispatch}
+            'convex_LV': ConvexLinearVoltageBatteryDispatch,
+            'load_following_heuristic': HeuristicLoadFollowingDispatch}
         if self.battery_dispatch in self._battery_dispatch_model_options:
             self.battery_dispatch_class = self._battery_dispatch_model_options[self.battery_dispatch]
             if 'heuristic' in self.battery_dispatch:

--- a/hopp/simulation/technologies/dispatch/hybrid_dispatch_options.py
+++ b/hopp/simulation/technologies/dispatch/hybrid_dispatch_options.py
@@ -36,6 +36,8 @@ class HybridDispatchOptions:
                 'n_clusters': int (default = 30)
                 'clustering_weights' : dict (default = {}). Custom weights used for classification metrics for data clustering.  If empty, default weights will be used.  
                 'clustering_divisions' : dict (default = {}).  Custom number of averaging periods for classification metrics for data clustering.  If empty, default values will be used.  
+                'use_higher_hours' : bool (default = False), if True, the simulation will run extra hours analysis (must be used with load following)
+                'higher_hours' : dict (default = {}). Higher hour count parameters: the value of power that must be available above the schedule and the number of hours in a row   
                 }
         """
         self.solver: str = 'cbc'
@@ -54,6 +56,9 @@ class HybridDispatchOptions:
         self.n_clusters: int = 30
         self.clustering_weights: dict = {}
         self.clustering_divisions: dict = {}
+
+        self.use_higher_hours: bool = False
+        self.higher_hours: dict = {}
 
         if dispatch_options is not None:
             for key, value in dispatch_options.items():

--- a/hopp/simulation/technologies/dispatch/plot_tools.py
+++ b/hopp/simulation/technologies/dispatch/plot_tools.py
@@ -322,6 +322,12 @@ def plot_generation_profile(hybrid: HybridSimulation,
     ax1.legend(fontsize=font_size-2, loc='upper left')
     ax1.set_ylabel('Power (MW)', fontsize=font_size)
 
+    if hybrid.site.follow_desired_schedule:
+        desired_load = [p for p in hybrid.site.desired_schedule[time_slice]]
+        ax1.plot(time, desired_load, 'b--', label='Price')
+        ax1.set_ylabel('Desired Load', fontsize=font_size)
+        ax1.legend(fontsize=font_size-2, loc='upper right')
+
     ax2 = ax1.twinx()
 
     price = [p * hybrid.ppa_price[0] for p in hybrid.site.elec_prices.data[time_slice]]
@@ -331,6 +337,9 @@ def plot_generation_profile(hybrid: HybridSimulation,
     plt.xlabel('Time (hours)', fontsize=font_size)
     plt.title('Net Generation', fontsize=font_size)
 
+
+    plt.xlabel('Time (hours)', fontsize=font_size)
+    plt.title('Net Generation', fontsize=font_size)
     plt.tight_layout()
 
     if plot_filename is not None:

--- a/hopp/simulation/technologies/dispatch/power_storage/heuristic_load_following_dispatch.py
+++ b/hopp/simulation/technologies/dispatch/power_storage/heuristic_load_following_dispatch.py
@@ -1,0 +1,58 @@
+import pyomo.environ as pyomo
+from pyomo.environ import units as u
+
+import PySAM.BatteryStateful as BatteryModel
+import PySAM.Singleowner as Singleowner
+
+from hopp.simulation.technologies.dispatch.power_storage.simple_battery_dispatch_heuristic import SimpleBatteryDispatchHeuristic
+
+
+class HeuristicLoadFollowingDispatch(SimpleBatteryDispatchHeuristic):
+    """Fixes battery dispatch operations based power available from power generation profiles and 
+        power demand profile.
+
+    Currently, enforces available generation and grid limit assuming no battery charging from grid
+    """
+    def __init__(self,
+                 pyomo_model: pyomo.ConcreteModel,
+                 index_set: pyomo.Set,
+                 system_model: BatteryModel.BatteryStateful,
+                 financial_model: Singleowner.Singleowner,
+                 fixed_dispatch: list = None,
+                 block_set_name: str = 'heuristic_load_following_battery',
+                 include_lifecycle_count: bool = False):
+        """
+
+        :param fixed_dispatch: list of normalized values [-1, 1] (Charging (-), Discharging (+))
+        """
+        super().__init__(pyomo_model,
+                         index_set,
+                         system_model,
+                         financial_model,
+                         fixed_dispatch,
+                         block_set_name=block_set_name,
+                         include_lifecycle_count=False)
+
+    def set_fixed_dispatch(self, gen: list, grid_limit: list, goal_power: list):
+        """Sets charge and discharge power of battery dispatch using fixed_dispatch attribute and enforces available
+        generation and grid limits.
+
+        """
+        self.check_gen_grid_limit(gen, grid_limit)
+        self._set_power_fraction_limits(gen, grid_limit)
+        self._heuristic_method(gen, goal_power)
+        self._fix_dispatch_model_variables()
+
+    def _heuristic_method(self, gen, goal_power):
+        """ Enforces battery power fraction limits and sets _fixed_dispatch attribute
+            Sets the _fixed_dispatch based on goal_power and gen (power genration profile)
+        """
+        for t in self.blocks.index_set():
+            fd = (goal_power[t] - gen[t]) / self.maximum_power
+            if fd > 0.0:    # Discharging
+                if fd > self.max_discharge_fraction[t]:
+                    fd = self.max_discharge_fraction[t]
+            elif fd < 0.0:  # Charging
+                if - fd > self.max_charge_fraction[t]:
+                    fd = - self.max_charge_fraction[t]
+            self._fixed_dispatch[t] = fd        

--- a/hopp/simulation/technologies/dispatch/power_storage/heuristic_load_following_dispatch.py
+++ b/hopp/simulation/technologies/dispatch/power_storage/heuristic_load_following_dispatch.py
@@ -8,7 +8,7 @@ from hopp.simulation.technologies.dispatch.power_storage.simple_battery_dispatch
 
 
 class HeuristicLoadFollowingDispatch(SimpleBatteryDispatchHeuristic):
-    """Fixes battery dispatch operations based power available from power generation profiles and 
+    """Operates the battery based on heuristic rules to meet the demand profile based power available from power generation profiles and 
         power demand profile.
 
     Currently, enforces available generation and grid limit assuming no battery charging from grid

--- a/hopp/simulation/technologies/dispatch/power_storage/simple_battery_dispatch_heuristic.py
+++ b/hopp/simulation/technologies/dispatch/power_storage/simple_battery_dispatch_heuristic.py
@@ -86,7 +86,7 @@ class SimpleBatteryDispatchHeuristic(SimpleBatteryDispatch):
             soc = soc0 + self.time_duration[0] * (self.charge_efficiency / 100. * charge_power) / self.capacity
         else:
             soc = soc0
-        soc = max(0, min(1, soc))
+        soc = max(0.1, min(0.9, soc))
         return soc
 
     def _heuristic_method(self, _):

--- a/hopp/simulation/technologies/dispatch/power_storage/simple_battery_dispatch_heuristic.py
+++ b/hopp/simulation/technologies/dispatch/power_storage/simple_battery_dispatch_heuristic.py
@@ -71,17 +71,17 @@ class SimpleBatteryDispatchHeuristic(SimpleBatteryDispatch):
     @staticmethod
     def enforce_power_fraction_simple_bounds(power_fraction) -> float:
         """ Enforces simple bounds (0,1) for battery power fractions."""
-        if power_fraction > 1.0:
-            power_fraction = 1.0
-        elif power_fraction < 0.0:
-            power_fraction = 0.0
+        if power_fraction > 0.9:
+            power_fraction = 0.9
+        elif power_fraction < 0:
+            power_fraction = 0
         return power_fraction
 
     def update_soc(self, power_fraction, soc0) -> float:
-        if power_fraction > 0.0:
+        if power_fraction > 0.1:
             discharge_power = power_fraction * self.maximum_power
             soc = soc0 - self.time_duration[0] * (1/(self.discharge_efficiency/100.) * discharge_power) / self.capacity
-        elif power_fraction < 0.0:
+        elif power_fraction < 0.9:
             charge_power = - power_fraction * self.maximum_power
             soc = soc0 + self.time_duration[0] * (self.charge_efficiency / 100. * charge_power) / self.capacity
         else:

--- a/hopp/simulation/technologies/grid.py
+++ b/hopp/simulation/technologies/grid.py
@@ -44,7 +44,8 @@ class Grid(PowerSource):
         self.schedule_curtailed = [0.]
         self.schedule_curtailed_percentage = 0.0
 
-    def simulate_grid_connection(self, hybrid_size_kw: float, total_gen: list, project_life: int, lifetime_sim: bool, total_gen_max_feasible_year1: list):
+    def simulate_grid_connection(self, hybrid_size_kw: float, total_gen: list, project_life: int, lifetime_sim: bool, \
+        total_gen_max_feasible_year1: list, dispatch_options=None):
         """
         Sets up and simulates hybrid system grid connection. Additionally, calculates missed load and curtailment (due to schedule) when a desired load is provided.
 
@@ -58,6 +59,8 @@ class Grid(PowerSource):
             For simulation modules which support simulating each year of the project_life, whether or not to do so; otherwise the first year data is repeated
         :param total_gen_max_feasible_year1: ``list``,
             Maximum generation profile of the hybrid system (for capacity payments) [kWh]
+        :param dispatch_options: :class:`HybridDispatchOptions`
+            Hybrid dispatch options class, deliminates if the higher power analysis for frequency regulation is run
         """
         if self.site.follow_desired_schedule:
             # Desired schedule sets the upper bound of the system output, any over generation is curtailed
@@ -72,8 +75,68 @@ class Grid(PowerSource):
             self.schedule_curtailed = [gen - schedule if gen > schedule else 0. for (gen, schedule) in
                                             zip(total_gen, lifetime_schedule)]
             self.schedule_curtailed_percentage = sum(self.schedule_curtailed)/sum(lifetime_schedule)
+
+            # NOTE: This is currently only happening for load following, would be good to make it more general
+            #           i.e. so that this analysis can be used when load following isn't being used (without storage)
+            #           for comparison 
+            N_hybrid = len(self.generation_profile)
+
+            final_power_production = total_gen
+            schedule = [x for x in lifetime_schedule]
+            print(len(final_power_production), len(schedule))
+            hybrid_power = [(final_power_production[x] - (schedule[x]*0.95)) for x in range(len(final_power_production))]
+
+            load_met = len([i for i in hybrid_power if i  >= 0])
+            self.time_load_met = 100 * load_met/N_hybrid
+
+            final_power_array = np.array(final_power_production)
+            power_met = np.where(final_power_array > schedule, schedule, final_power_array)
+            self.capacity_factor_load = np.sum(power_met) / np.sum(schedule) * 100
+
+            print('Percent of time firm power requirement is met: ', np.round(self.time_load_met,2))
+            print('Percent total firm power requirement is satisfied: ', np.round(self.capacity_factor_load,2))
+
+            ERS_keys = ['min_regulation_hours', 'min_regulation_power']
+            if dispatch_options.use_higher_hours :
+                """
+                Frequency regulation analysis for providing essential reliability services (ERS) availability operating case:
+                        Finds how many hours (in the group specified group size above the specified minimum
+                        power requirement) that the system has available to extra power that could be used to 
+                        provide ERS
+                Args:
+                    :param dispatch_options: need additional ERS arguments
+                                        'min_regulation_hours': minimum size of hours in a group to be considered for ERS (>= 1)
+                                        'min_regulation_power': minimum power available over the whole group of hours to be 
+                                                considered for ERS (> 0, in kW)
+
+                :returns: total_number_hours
+
+                """
+
+                # Performing frequency regulation analysis:
+                #    finding how many groups of hours satisfiy the ERS minimum power requirement
+                min_regulation_hours = dispatch_options.higher_hours['min_regulation_hours']
+                min_regulation_power = dispatch_options.higher_hours['min_regulation_power']
+
+                frequency_power_array = np.array(hybrid_power)
+                frequency_test = np.where(frequency_power_array > min_regulation_power, frequency_power_array, 0)
+                mask = (frequency_test!=0).astype(int)
+                padded_mask = np.pad(mask,(1,), "constant")
+                edge_mask = padded_mask[1:] - padded_mask[:-1]  # finding the difference between each array value
+
+                group_starts = np.where(edge_mask == 1)[0]
+                group_stops = np.where(edge_mask == -1)[0]
+
+                # Find groups and drop groups that are too small
+                groups = [group for group in zip(group_starts,group_stops) if ((group[1]-group[0]) >= min_regulation_hours)]
+                group_lengths = [len(final_power_production[group[0]:group[1]]) for group in groups]
+                self.total_number_hours = sum(group_lengths)
+
+                print('Total number of hours available for ERS: ', np.round(self.total_number_hours,2))
+
         else:
             self.generation_profile = total_gen
+
         self.system_capacity_kw = hybrid_size_kw  # TODO: Should this be interconnection limit?
         self.gen_max_feasible = np.minimum(total_gen_max_feasible_year1, self.interconnect_kw * self.site.interval / 60)
         self.simulate_power(project_life, lifetime_sim)

--- a/tests/hopp/test_dispatch.py
+++ b/tests/hopp/test_dispatch.py
@@ -638,6 +638,34 @@ def test_hybrid_dispatch_heuristic(site):
     assert sum(hybrid_plant.battery.dispatch.discharge_power) > 0.0
 
 
+def test_hybrid_dispatch_baseload_heuristic_and_analysis(site):
+
+    desired_schedule = 8760*[20]
+
+    desired_schedule_site = SiteInfo(flatirons_site,
+                                     desired_schedule=desired_schedule)
+    wind_solar_battery = {key: technologies[key] for key in ('pv', 'wind', 'battery')}
+
+    dispatch_options = {'battery_dispatch': 'load_following_heuristic',
+                        'use_higher_hours': True, 
+                        'higher_hours': {'min_regulation_hours': 4, 'min_regulation_power': 5000}}
+
+    print(wind_solar_battery)
+    print(site)
+    print(interconnect_mw)
+    print(dispatch_options)
+    hybrid_plant = HybridSimulation(wind_solar_battery, desired_schedule_site, interconnect_mw * 1000,
+                                    dispatch_options=dispatch_options)
+
+
+    hybrid_plant.simulate(1)
+
+    assert hybrid_plant.grid.time_load_met == pytest.approx(93.9, 1e-2)
+    assert hybrid_plant.grid.capacity_factor_load == pytest.approx(95.75, 1e-2)
+    assert hybrid_plant.grid.total_number_hours == pytest.approx(4277, 1e-2)
+
+
+
 def test_hybrid_dispatch_one_cycle_heuristic(site):
     dispatch_options = {'battery_dispatch': 'one_cycle_heuristic',
                         'grid_charging': False}


### PR DESCRIPTION
Adding heuristic load following dispatch method in power_storage
Added simulate_hybrid_load_following.py as an example of how to run the load following heuristic method
Added load signal to battery generation plots

- [x] Add test: test_hybrid_dispatch_baseload_heuristic_and_analysis and test_hybrid_dispatch_one_cycle_heuristic_baseload from https://github.com/bayc/HOPP-1/blob/archive/new_batt_heuristic/tests/hybrid/test_dispatch.py
- [x] Add baseload options to hybrid_dispatch_options dict: https://github.com/bayc/HOPP-1/blob/archive/new_batt_heuristic/hybrid/dispatch/hybrid_dispatch_options.py#L55
- [x] Add analysis code to grid.py from: https://github.com/bayc/HOPP-1/blob/archive/new_batt_heuristic/hybrid/grid.py#L81