### PR TITLE
Refactor SiteInfo

### DIFF
--- a/examples/CSP_PV_Battery_Analysis/simulation_init.py
+++ b/examples/CSP_PV_Battery_Analysis/simulation_init.py
@@ -82,8 +82,7 @@ def init_hybrid_plant(techs_in_sim: list, is_test: bool = False, ud_techs: dict 
         "lon": -116.7830,
         "elev": 561,
         "tz": 1,
-        "no_wind": True
-        }
+    }
     solar_file = example_root + "02_weather_data/daggett_ca_34.865371_-116.783023_psmv3_60_tmy.csv"
     prices_file = example_root + "03_cost_load_price_data/constant_norm_prices.csv"
     desired_schedule_file = example_root + "03_cost_load_price_data/desired_schedule_normalized.csv"
@@ -98,7 +97,8 @@ def init_hybrid_plant(techs_in_sim: list, is_test: bool = False, ud_techs: dict 
     site = SiteInfo(site_data, 
                     solar_resource_file=solar_file, 
                     grid_resource_file=prices_file,
-                    desired_schedule=desired_schedule
+                    desired_schedule=desired_schedule,
+                    wind=False
                     )
 
     # Load in system costs

--- a/examples/offshore-hybrid/wind-h2.py
+++ b/examples/offshore-hybrid/wind-h2.py
@@ -160,14 +160,14 @@ def setup_hopp(plant_config, turbine_config, wind_resource, orbit_project, flori
     hopp_site_input_data["lat"] = plant_config["project_location"]["lat"]
     hopp_site_input_data["lon"] = plant_config["project_location"]["lon"]
     hopp_site_input_data["year"] = plant_config["wind_resource_year"]
-    hopp_site_input_data["no_solar"] = not plant_config["project_parameters"]["solar"]
+    solar = plant_config["project_parameters"]["solar"]
 
     # set desired schedule based on electrolyzer capacity
     desired_schedule = [plant_config["electrolyzer"]["rating"]]*8760
     desired_schedule = []
 
     # generate HOPP SiteInfo class instance
-    hopp_site = SiteInfo(hopp_site_input_data, hub_height=turbine_config["hub_height"], desired_schedule=desired_schedule)
+    hopp_site = SiteInfo(hopp_site_input_data, hub_height=turbine_config["hub_height"], desired_schedule=desired_schedule, solar=solar)
 
     # replace wind data with previously downloaded and adjusted wind data
     hopp_site.wind_resource = wind_resource

--- a/hopp/eco/hopp_mgmt.py
+++ b/hopp/eco/hopp_mgmt.py
@@ -21,8 +21,8 @@ def setup_hopp(
     hopp_site_input_data["lat"] = plant_config["project_location"]["lat"]
     hopp_site_input_data["lon"] = plant_config["project_location"]["lon"]
     hopp_site_input_data["year"] = plant_config["wind_resource_year"]
-    hopp_site_input_data["no_wind"] = not plant_config["project_parameters"]["wind"]
-    hopp_site_input_data["no_solar"] = not plant_config["project_parameters"]["solar"]
+    wind = plant_config["project_parameters"]["wind"]
+    solar = plant_config["project_parameters"]["solar"]
 
     # set desired schedule based on electrolyzer capacity
     desired_schedule = [plant_config["electrolyzer"]["rating"]] * 8760
@@ -33,6 +33,8 @@ def setup_hopp(
         hopp_site_input_data,
         hub_height=turbine_config["hub_height"],
         desired_schedule=desired_schedule,
+        wind=wind,
+        solar=solar
     )
 
     # replace wind data with previously downloaded and adjusted wind data

--- a/hopp/simulation/technologies/sites/site_info.py
+++ b/hopp/simulation/technologies/sites/site_info.py
@@ -58,11 +58,11 @@ class SiteInfo(BaseClass):
     solar_resource_file: Union[Path, str] = field(default="", converter=resource_file_converter)
     wind_resource_file: Union[Path, str] = field(default="", converter=resource_file_converter)
     grid_resource_file: Union[Path, str] = field(default="", converter=resource_file_converter)
-    hub_height: hopp_float_type = hopp_float_type(97.)
+    hub_height: hopp_float_type = field(default=97., converter=hopp_float_type)
     capacity_hours: NDArray = field(default=[], converter=converter(bool))
     desired_schedule: NDArrayFloat = field(default=[], converter=converter())
-    solar: bool = True
-    wind: bool = True
+    solar: bool = field(default=True)
+    wind: bool = field(default=True)
 
     # Set in post init hook
     n_timesteps: int = field(init=False, default=None)

--- a/hopp/to_organize/hopp_tools_steel.py
+++ b/hopp/to_organize/hopp_tools_steel.py
@@ -114,11 +114,10 @@ def set_site_info(hopp_dict, site_df, sample_site):
     lon = float(lon)
     sample_site['lat'] = lat
     sample_site['lon'] = lon
-    sample_site['no_solar'] = False
     # if solar_size_mw>0:
-    #     sample_site['no_solar'] = False
+    #     sample_site['solar'] = True
     # else:
-    #     sample_site['no_solar'] = True
+    #     sample_site['solar'] = False
 
     hopp_dict.add('Configuration', {'sample_site': sample_site})
 

--- a/hopp/tools/dispatch/csp_pv_battery_plot.py
+++ b/hopp/tools/dispatch/csp_pv_battery_plot.py
@@ -65,8 +65,7 @@ def init_hybrid_plant():
         "elev": 641,
         "year": 2012,
         "tz": -8,
-        "no_wind": True
-        }
+    }
 
     root = "C:/Users/WHamilt2/Documents/Projects/HOPP/CSP_PV_battery_dispatch_plots/"
     solar_file = root + "34.865371_-116.783023_psmv3_60_tmy.csv"
@@ -84,7 +83,8 @@ def init_hybrid_plant():
     site = SiteInfo(site_data,
                     solar_resource_file=solar_file,
                     grid_resource_file=prices_file,
-                    desired_schedule=desired_schedule
+                    desired_schedule=desired_schedule,
+                    wind=False
                     )
 
     technologies = {'tower': {

--- a/hopp/tools/hopp_tools.py
+++ b/hopp/tools/hopp_tools.py
@@ -39,7 +39,6 @@ def set_site_info(site_df, sample_site):
     lon = float(lon)
     sample_site['lat'] = lat
     sample_site['lon'] = lon
-    sample_site['no_solar'] = False
 
     return site_df, sample_site
 

--- a/hopp/type_dec.py
+++ b/hopp/type_dec.py
@@ -21,11 +21,11 @@ import os.path
 
 from hopp.utilities.log import hybrid_logger as logger
 
-
 ### Define general data types used throughout
 
 hopp_path = Path(__file__).parent.parent
 hopp_float_type = np.float64
+hopp_int_type = np.int_
 
 NDArrayFloat = npt.NDArray[hopp_float_type]
 NDArrayInt = npt.NDArray[np.int_]
@@ -35,17 +35,20 @@ NDArrayObject = npt.NDArray[np.object_]
 
 ### Custom callables for attrs objects and functions
 
-def hopp_array_converter(data: Iterable) -> np.ndarray:
-    try:
-        a = np.array(data, dtype=hopp_float_type)
-    except TypeError as e:
-        raise TypeError(e.args[0] + f". Data given: {data}")
-    return a
+def hopp_array_converter(dtype: Any = hopp_float_type) -> Callable:
+    def converter(data: Iterable):
+        try:
+            a = np.array(data, dtype=dtype)
+        except TypeError as e:
+            raise TypeError(e.args[0] + f". Data given: {data}")
+        return a
 
-def resource_file_converter(resource_file: str) -> None:
-    # If the default value of an empty string is supplied, just pass through the default
+    return converter
+
+def resource_file_converter(resource_file: str) -> Union[Path, str]:
+    # If the default value of an empty string is supplied, return empty path obj
     if resource_file == "":
-        return resource_file
+        return ""
 
     # Check the path relative to the hopp directory for the resource file and return if it exists
     resource_file_path = str(hopp_path / resource_file)

--- a/hopp/type_dec.py
+++ b/hopp/type_dec.py
@@ -36,6 +36,28 @@ NDArrayObject = npt.NDArray[np.object_]
 ### Custom callables for attrs objects and functions
 
 def hopp_array_converter(dtype: Any = hopp_float_type) -> Callable:
+    """
+    Returns a converter function for `attrs` fields to convert data into a numpy array of a specified dtype.
+    This function is primarily used to ensure that data provided to an `attrs` class is converted to the
+    appropriate numpy array type.
+
+    Args:
+        dtype (Any, optional): The desired data type for the numpy array. Defaults to `hopp_float_type`.
+
+    Returns:
+        Callable: A converter function that takes an iterable and returns it as a numpy array of the specified dtype.
+
+    Raises:
+        TypeError: If the provided data cannot be converted to the desired numpy dtype.
+
+    Examples:
+        >>> converter = hopp_array_converter()
+        >>> converter([1.0, 2.0, 3.0])
+        array([1., 2., 3.])
+        >>> converter = hopp_array_converter(dtype=np.int32)
+        >>> converter([1, 2, 3])
+        array([1, 2, 3], dtype=int32)
+    """
     def converter(data: Iterable):
         try:
             a = np.array(data, dtype=dtype)

--- a/tests/hopp/hopp_tools_test.py
+++ b/tests/hopp/hopp_tools_test.py
@@ -35,7 +35,7 @@ def set_site_info(xl, turbine_model, site_location, sample_site):
     lon = float(lon)
     sample_site['lat'] = lat
     sample_site['lon'] = lon
-    sample_site['no_solar'] = True
+    sample_site['solar'] = False
 
     return site_df, sample_site
 

--- a/tests/hopp/test_layout.py
+++ b/tests/hopp/test_layout.py
@@ -205,37 +205,6 @@ def test_hybrid_layout_solar_only(site):
         assert buffer_region[i] == pytest.approx(expected_buffer_region[i], 1e-3)
 
 
-def test_kml_file_read():
-    filepath = Path(__file__).absolute().parent / "layout_example.kml"
-    site_data = {'kml_file': filepath}
-    solar_resource_file = Path(__file__).absolute().parent.parent.parent / "resource_files" / "solar" / "35.2018863_-101.945027_psmv3_60_2012.csv"
-    wind_resource_file = Path(__file__).absolute().parent.parent.parent / "resource_files" / "wind" / "35.2018863_-101.945027_windtoolkit_2012_60min_80m_100m.srw"
-    site = SiteInfo(site_data, solar_resource_file=solar_resource_file, wind_resource_file=wind_resource_file)
-    site.plot()
-    assert np.array_equal(np.round(site.polygon.bounds), [ 681175., 4944970.,  686386., 4949064.])
-    assert site.polygon.area * 3.86102e-7 == pytest.approx(2.3393, abs=0.01) # m2 to mi2
-
-
-def test_kml_file_append():
-    filepath = Path(__file__).absolute().parent / "layout_example.kml"
-    site_data = {'kml_file': filepath}
-    solar_resource_file = Path(__file__).absolute().parent.parent.parent / "resource_files" / "solar" / "35.2018863_-101.945027_psmv3_60_2012.csv"
-    wind_resource_file = Path(__file__).absolute().parent.parent.parent / "resource_files" / "wind" / "35.2018863_-101.945027_windtoolkit_2012_60min_80m_100m.srw"
-    site = SiteInfo(site_data, solar_resource_file=solar_resource_file, wind_resource_file=wind_resource_file)
-
-    x = site.polygon.centroid.x
-    y = site.polygon.centroid.y
-    turb_coords = [x - 500, y - 500]
-    solar_region = Polygon(((x, y), (x, y + 5000), (x + 5000, y), (x + 5000, y + 5000)))
-
-    filepath_new = Path(__file__).absolute().parent / "layout_example2.kml"
-    site.kml_write(filepath_new, turb_coords, solar_region)
-    assert filepath_new.exists()
-    k, valid_region, lat, lon = SiteInfo.kml_read(filepath)
-    assert valid_region.area > 0
-    os.remove(filepath_new)
-
-
 def test_system_electrical_sizing(site):
     target_solar_kw = 1e5
     target_dc_ac_ratio = 1.34

--- a/tests/hopp/test_site_info.py
+++ b/tests/hopp/test_site_info.py
@@ -108,13 +108,13 @@ def test_site_init_improper_schedule():
 def test_site_init_no_wind():
     """Should initialize without pulling wind data."""
     data = copy.deepcopy(flatirons_site)
-    data["no_wind"] = True
 
     site = SiteInfo(
         data, 
         solar_resource_file=solar_resource_file,
         wind_resource_file=wind_resource_file,
         grid_resource_file=grid_resource_file,
+        wind=False
     )
 
     assert site.wind_resource is None
@@ -123,13 +123,13 @@ def test_site_init_no_wind():
 def test_site_init_no_solar():
     """Should initialize without pulling wind data."""
     data = copy.deepcopy(flatirons_site)
-    data["no_solar"] = True
 
     site = SiteInfo(
         data, 
         solar_resource_file=solar_resource_file,
         wind_resource_file=wind_resource_file,
         grid_resource_file=grid_resource_file,
+        solar=False
     )
 
     assert site.solar_resource is None

--- a/tests/hopp/test_site_info.py
+++ b/tests/hopp/test_site_info.py
@@ -1,0 +1,159 @@
+import os
+import copy
+from pathlib import Path
+
+import pytest
+from pytest import fixture
+from shapely.geometry import Polygon
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from hopp.simulation.technologies.sites import SiteInfo, flatirons_site
+from hopp import ROOT_DIR
+
+solar_resource_file = os.path.join(
+    ROOT_DIR.parent, "resource_files", "solar", 
+    "35.2018863_-101.945027_psmv3_60_2012.csv"
+)
+wind_resource_file = os.path.join(
+    ROOT_DIR.parent, "resource_files", "wind", 
+    "35.2018863_-101.945027_windtoolkit_2012_60min_80m_100m.srw"
+)
+grid_resource_file = os.path.join(
+    ROOT_DIR.parent, "resource_files", "grid", 
+    "pricing-data-2015-IronMtn-002_factors.csv"
+)
+kml_filepath = Path(__file__).absolute().parent / "layout_example.kml"
+
+
+@fixture
+def site():
+    return SiteInfo(
+        flatirons_site,
+        solar_resource_file=solar_resource_file,
+        wind_resource_file=wind_resource_file,
+        grid_resource_file=grid_resource_file
+    )
+
+
+def test_site_init(site):
+    """Site should initialize properly."""
+    assert site is not None
+
+    # data
+    assert site.lat == flatirons_site["lat"]
+    assert site.lon == flatirons_site["lon"]
+    assert site.year == flatirons_site["year"]
+    assert site.tz == flatirons_site["tz"]
+    assert site.urdb_label == flatirons_site["urdb_label"]
+
+    # resources
+    assert site.solar_resource is not None
+    assert site.wind_resource is not None
+    assert site.elec_prices is not None
+
+    # time periods
+    assert site.n_timesteps == 8760
+    assert site.n_periods_per_day == 24
+    assert site.interval == 60
+    assert_array_equal(site.capacity_hours, [False] * site.n_timesteps)
+    assert_array_equal(site.desired_schedule, [])
+
+    # polygon
+    assert site.polygon is not None
+    assert site.vertices is not None
+
+    # unset
+    assert site.kml_data is None
+
+
+def test_site_init_kml_read():
+    """Should initialize via kml file."""
+    site = SiteInfo({"kml_file": kml_filepath}, solar_resource_file=solar_resource_file, wind_resource_file=wind_resource_file)
+
+    assert site.kml_data is not None
+    assert site.polygon is not None
+
+
+def test_site_init_missing_coords():
+    """Should fail if lat/lon missing."""
+    data = copy.deepcopy(flatirons_site)
+    del data["lat"]
+    del data["lon"]
+
+    with pytest.raises(ValueError):
+        SiteInfo(data)
+
+    data["lat"] = flatirons_site["lat"]
+
+    # should still fail because lon is missing
+    with pytest.raises(ValueError):
+        SiteInfo(data)
+
+
+def test_site_init_improper_schedule():
+    """Should fail if the desired schedule mismatches the number of timesteps."""
+    data = copy.deepcopy(flatirons_site)
+
+    with pytest.raises(ValueError):
+        SiteInfo(
+            data, 
+            solar_resource_file=solar_resource_file,
+            wind_resource_file=wind_resource_file,
+            grid_resource_file=grid_resource_file,
+            desired_schedule=np.array([1])
+        )
+
+
+def test_site_init_no_wind():
+    """Should initialize without pulling wind data."""
+    data = copy.deepcopy(flatirons_site)
+    data["no_wind"] = True
+
+    site = SiteInfo(
+        data, 
+        solar_resource_file=solar_resource_file,
+        wind_resource_file=wind_resource_file,
+        grid_resource_file=grid_resource_file,
+    )
+
+    assert site.wind_resource is None
+
+    
+def test_site_init_no_solar():
+    """Should initialize without pulling wind data."""
+    data = copy.deepcopy(flatirons_site)
+    data["no_solar"] = True
+
+    site = SiteInfo(
+        data, 
+        solar_resource_file=solar_resource_file,
+        wind_resource_file=wind_resource_file,
+        grid_resource_file=grid_resource_file,
+    )
+
+    assert site.solar_resource is None
+
+
+def test_site_kml_file_read():
+    site_data = {'kml_file': kml_filepath}
+    site = SiteInfo(site_data, solar_resource_file=solar_resource_file, wind_resource_file=wind_resource_file)
+    assert np.array_equal(np.round(site.polygon.bounds), [ 681175., 4944970.,  686386., 4949064.])
+    assert site.polygon.area * 3.86102e-7 == pytest.approx(2.3393, abs=0.01) # m2 to mi2
+
+
+def test_site_kml_file_append():
+    site_data = {'kml_file': kml_filepath}
+    site = SiteInfo(site_data, solar_resource_file=solar_resource_file, wind_resource_file=wind_resource_file)
+
+    x = site.polygon.centroid.x
+    y = site.polygon.centroid.y
+    turb_coords = [x - 500, y - 500]
+    solar_region = Polygon(((x, y), (x, y + 5000), (x + 5000, y), (x + 5000, y + 5000)))
+
+    filepath_new = Path(__file__).absolute().parent / "layout_example2.kml"
+    site.kml_write(filepath_new, turb_coords, solar_region)
+    assert filepath_new.exists()
+    k, valid_region, lat, lon = SiteInfo.kml_read(kml_filepath)
+    assert valid_region.area > 0
+    os.remove(filepath_new)


### PR DESCRIPTION
<!--
resolves #145 

## Changes

- Updates `SiteInfo` to use `attrs`
- Adds basic `SiteInfo` unit tests
- Changes how users specify option to disable wind/solar resource pull
- Updates docstrings to use Google Sphinx format
-->

# Refactor site_info to use the attrs library and method of class definition

This pull request refactors the `SiteInfo` class to use the attrs library dataclass functionality. This cleans up the `__init__` function and doesn't require the user to write some boilerplate code for each class. It also adds the ability to define converters and validators for input, building robustness into the code. Basic unit tests are added for `SiteInfo` and the docstrings involved have been updated to use Google Sphinx [format](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html).

## Related issue
resolves #145 

## Impacted areas of the software
Mainly `site_info.py`, with updates to wind/solar resource inputs as needed elsewhere.

## Additional supporting information
None

## Test results, if applicable
Build passing [here](https://github.com/camirmas/HOPP/actions/runs/5943969928)
