### PR TITLE
Fix min_intrarow_spacing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8 ]
+        python-version: [ 3.9, 3.8 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/hybrid/layout/wind_layout_tools.py
+++ b/hybrid/layout/wind_layout_tools.py
@@ -176,7 +176,7 @@ def get_best_grid(site_shape: BaseGeometry,
             maximum_chord = max_distance(site_shape)
             
             max_intrarow_spacing = min(max_spacing, max_spacing * grid_aspect, maximum_chord)
-            min_intrarow_spacing = min(max(min_spacing, min_spacing * grid_aspect), max_intrarow_spacing)
+            min_intrarow_spacing = min(max(min_spacing, min_spacing / grid_aspect), max_intrarow_spacing)
             
             interrow_offset, _ = binary_search_float(
                 grid_objective,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Cython
 NREL-PySAM-stubs==3.0.0
 NREL-PySAM==3.0.0
 Pillow
-Pyomo>=6.1.2
+Pyomo
 diskcache
 fastkml
 floris
@@ -17,7 +17,7 @@ nevergrad
 numpy
 numpy-financial
 optuna
-pandas<=2.0.0
+pandas
 pint
 pvmismatch
 pyDOE2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ nevergrad
 numpy
 numpy-financial
 optuna
-pandas
+pandas>=2.0
 pint
 pvmismatch
 pyDOE2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cython
-NREL-PySAM-stubs>=3.0,<4.0
-NREL-PySAM>=3.0,<4.0
+NREL-PySAM-stubs==3.0.0
+NREL-PySAM==3.0.0
 Pillow
 Pyomo>=6.1.2
 diskcache
@@ -17,7 +17,7 @@ nevergrad
 numpy
 numpy-financial
 optuna
-pandas>=2.0
+pandas<=2.0.0
 pint
 pvmismatch
 pyDOE2
@@ -29,7 +29,6 @@ python-dotenv
 python-rapidjson
 pytz
 requests
-responses
 scikit-learn
 scikit-optimize
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cython
-NREL-PySAM-stubs==3.0.0
-NREL-PySAM==3.0.0
+NREL-PySAM-stubs>=3.0,<4.0
+NREL-PySAM>=3.0,<4.0
 Pillow
 Pyomo>=6.1.2
 diskcache
@@ -17,7 +17,7 @@ nevergrad
 numpy
 numpy-financial
 optuna
-pandas<=2.0.0
+pandas>=2.0
 pint
 pvmismatch
 pyDOE2
@@ -29,6 +29,7 @@ python-dotenv
 python-rapidjson
 pytz
 requests
+responses
 scikit-learn
 scikit-optimize
 scipy


### PR DESCRIPTION
In line 155, the `interrow_spacing` is calculated as `intrarow_spacing * grid_aspect`. So when `grid_aspect` < 1 then the interrow spacing can be less than the intrarow. The intrarow spacing is bounded by the min and max calcs in lines 178-179. The `min_intrarow_spacing` should depend on `min_spacing / grid_aspect` instead of `min_spacing * grid_aspect` so that when `interrow_spacing = intrarow_spacing * grid_aspect` happens, the min_spacing is respected.

Thanks to Maël for finding this issue.