### PR TITLE
Bug Fix: wind resource API download for user-specified hub-height

### DIFF
--- a/hopp/simulation/technologies/resource/wind_resource.py
+++ b/hopp/simulation/technologies/resource/wind_resource.py
@@ -83,8 +83,8 @@ class WindResource(Resource):
         file_resource_heights = dict()
 
         for h in heights:
-            file_resource_heights[h] = file_resource_base + '_' + str(h) + 'm.srw'
-            file_resource_full += "_" + str(h) + 'm'
+            file_resource_heights[int(h)] = file_resource_base + '_' + str(int(h)) + 'm.srw'
+            file_resource_full += "_" + str(int(h)) + 'm'
         file_resource_full += ".srw"
 
         self.file_resource_heights = file_resource_heights


### PR DESCRIPTION
fixed bug in API URL populating for hub-height. Changed lines 86 and 87 of hopp/simulation/technologies/resource/wind_resource.py in function calculate_heights_to_download()

Bug Description: if user specifies a hub-height when creating the site, for example:
`site = SiteInfo(sample_site,solar=True,wind=True,wave=False,hub_height = 80`,
an error would be thrown in the API call to download the wind_resource stating that the hub-height was not one of the available hub-heights (even though it is). This error is because the API URL has the hub-height value as a float, not an integer. For example, the url would contain `hubheight=80.0` (throws an error) rather than `hubheight=80` (doesn't throw an error). 

The hub height value of the url is set using the key(s) from the dictionary self.file_resource_heights which is created in the function calculate_heights_to_download(). The bug is fixed by setting the key(s) of self.file_resource_heights as an integer:
`file_resource_heights[int(h)] = file_resource_base + '_' + str(int(h)) + 'm.srw'`
