### PR TITLE
Solar plant updates

### DIFF
--- a/hopp/simulation/hybrid_simulation.py
+++ b/hopp/simulation/hybrid_simulation.py
@@ -826,7 +826,7 @@ class HybridSimulation(BaseClass):
         if self.pv:
             cf.pv = self.pv.capacity_factor
             hybrid_generation += self.pv.annual_energy_kwh
-            hybrid_capacity += self.pv.system_capacity_kw
+            hybrid_capacity += self.pv.system_capacity_kw / self.pv.dc_ac_ratio
         if self.wind:
             cf.wind = self.wind.capacity_factor
             hybrid_generation += self.wind.annual_energy_kwh

--- a/hopp/simulation/technologies/pv/pv_plant.py
+++ b/hopp/simulation/technologies/pv/pv_plant.py
@@ -35,7 +35,7 @@ class PVConfig(BaseClass):
 
         dc_degradation: Annual DC degradation for lifetime simulations [%/year]
         approx_nominal_efficiency: approx nominal efficiency depends on module type (standard crystalline silicon 19%, premium 21%, thin film 18%) [decimal]
-        modudule_unit_mass: Mass of the individual module unit (default to 11). [kg/m2]
+        modudule_unit_mass: Mass of the individual module unit (default to 11.092). [kg/m2]
     """
     system_capacity_kw: float = field(validator=gt_zero)
 
@@ -45,7 +45,7 @@ class PVConfig(BaseClass):
     fin_model: Optional[Union[str, dict, FinancialModelType]] = field(default=None)
     dc_degradation: Optional[List[float]] = field(default=None)
     approx_nominal_efficiency: Optional[float] = field(default=0.19)
-    module_unit_mass: Optional[float] = field(default=11)
+    module_unit_mass: Optional[float] = field(default=11.092)
 
 
 @define
@@ -110,7 +110,7 @@ class PVPlant(PowerSource):
         if self.config.module_unit_mass is not None:
             self.module_unit_mass = self.config.module_unit_mass
         else:
-            self.module_unit_mass = 11
+            self.module_unit_mass = 11.092
 
         if layout_model is not None:
             self.layout = layout_model

--- a/hopp/simulation/technologies/pv/pv_plant.py
+++ b/hopp/simulation/technologies/pv/pv_plant.py
@@ -8,6 +8,7 @@ import PySAM.Singleowner as Singleowner
 from hopp.simulation.technologies.financial import FinancialModelType
 from hopp.simulation.technologies.sites import SiteInfo
 from hopp.simulation.technologies.power_source import PowerSource
+from hopp.simulation.technologies.layout.pv_module import get_module_attribs
 from hopp.simulation.technologies.layout.pv_layout import PVLayout, PVGridParameters
 from hopp.simulation.technologies.financial.custom_financial_model import CustomFinancialModel
 from hopp.simulation.base import BaseClass
@@ -183,10 +184,11 @@ class PVPlant(PowerSource):
 
     @property
     def plant_area(self):
-        """Estimated Total Module Area [m2]"""
-        if self.approx_nominal_efficiency == 0:
-            raise ValueError("approx_nominal_efficiency cannot be zero.")
-        return self._system_model.SystemDesign.system_capacity / self.approx_nominal_efficiency
+        """Estimate Total Module Area [m2]"""
+        module_attribs = get_module_attribs(self._system_model)
+        num_modules = self.system_capacity_kw / module_attribs['P_mp_ref']
+        area = num_modules * module_attribs['area']
+        return  area
 
     @property
     def plant_mass(self):

--- a/hopp/simulation/technologies/pv/pv_plant.py
+++ b/hopp/simulation/technologies/pv/pv_plant.py
@@ -1,4 +1,5 @@
 from typing import List, Sequence, Optional, Union
+from xml.sax.handler import property_declaration_handler
 
 from attrs import define, field
 import PySAM.Pvwattsv8 as Pvwatts

--- a/hopp/simulation/technologies/pv/pv_plant.py
+++ b/hopp/simulation/technologies/pv/pv_plant.py
@@ -34,6 +34,7 @@ class PVConfig(BaseClass):
 
         dc_degradation: Annual DC degradation for lifetime simulations [%/year]
         approx_nominal_efficiency: approx nominal efficiency depends on module type (standard crystalline silicon 19%, premium 21%, thin film 18%) [decimal]
+        modudule_unit_mass: Mass of the individual module unit (default to 11). [kg/m2]
     """
     system_capacity_kw: float = field(validator=gt_zero)
 
@@ -43,6 +44,7 @@ class PVConfig(BaseClass):
     fin_model: Optional[Union[str, dict, FinancialModelType]] = field(default=None)
     dc_degradation: Optional[List[float]] = field(default=None)
     approx_nominal_efficiency: Optional[float] = field(default=0.19)
+    module_unit_mass: Optional[float] = field(default=11)
 
 
 @define
@@ -103,6 +105,11 @@ class PVPlant(PowerSource):
             self.approx_nominal_efficiency = self.config.approx_nominal_efficiency
         else:
             self.approx_nominal_efficiency = 0.19
+
+        if self.config.module_unit_mass is not None:
+            self.module_unit_mass = self.config.module_unit_mass
+        else:
+            self.module_unit_mass = 11
 
         if layout_model is not None:
             self.layout = layout_model
@@ -179,6 +186,11 @@ class PVPlant(PowerSource):
         if self.approx_nominal_efficiency == 0:
             raise ValueError("approx_nominal_efficiency cannot be zero.")
         return self._system_model.SystemDesign.system_capacity / self.approx_nominal_efficiency
+
+    @property
+    def plant_mass(self):
+        """Estimate Total Module Mass [kg]"""
+        return self.plant_area * self.module_unit_mass
 
     @property
     def capacity_factor(self) -> float:

--- a/hopp/simulation/technologies/pv/pv_plant.py
+++ b/hopp/simulation/technologies/pv/pv_plant.py
@@ -134,3 +134,26 @@ class PVPlant(PowerSource):
     def dc_degradation(self, dc_deg_per_year: Sequence):
         """Sets annual DC degradation for lifetime simulations [%/year]."""
         self._system_model.Lifetime.dc_degradation = dc_deg_per_year
+
+    @property
+    def dc_ac_ratio(self) -> float:
+        """DC to AC inverter loading ratio [ratio]."""
+        return self._system_model.SystemDesign.dc_ac_ratio
+
+    @dc_ac_ratio.setter
+    def dc_ac_ratio(self, inverter_loading_ratio: float):
+        """Sets DC to AC inverter loading ratio [ratio]."""
+        self._system_model.SystemDesign.dc_ac_ratio = inverter_loading_ratio
+
+    @property
+    def capacity_factor(self) -> float:
+        """System capacity factor [%]"""
+        if self.system_capacity_kw > 0:
+            return self._system_model.value("capacity_factor")*self._system_model.value("dc_ac_ratio")
+        else:
+            return 0
+        ### Use this version when updated to PySAM 4.2.0
+        # if self.system_capacity_kw > 0:
+        #     return self._system_model.value("capacity_factor_ac")
+        # else:
+        #     return 0

--- a/hopp/simulation/technologies/pv/pv_plant.py
+++ b/hopp/simulation/technologies/pv/pv_plant.py
@@ -1,5 +1,4 @@
 from typing import List, Sequence, Optional, Union
-from xml.sax.handler import property_declaration_handler
 
 from attrs import define, field
 import PySAM.Pvwattsv8 as Pvwatts
@@ -36,7 +35,7 @@ class PVConfig(BaseClass):
 
         dc_degradation: Annual DC degradation for lifetime simulations [%/year]
         approx_nominal_efficiency: approx nominal efficiency depends on module type (standard crystalline silicon 19%, premium 21%, thin film 18%) [decimal]
-        modudule_unit_mass: Mass of the individual module unit (default to 11.092). [kg/m2]
+        module_unit_mass: Mass of the individual module unit (default to 11.092). [kg/m2]
     """
     system_capacity_kw: float = field(validator=gt_zero)
 

--- a/hopp/simulation/technologies/pv/pv_plant.py
+++ b/hopp/simulation/technologies/pv/pv_plant.py
@@ -173,6 +173,12 @@ class PVPlant(PowerSource):
         else:
             raise NotImplementedError("Module type not set")
 
+    @property
+    def plant_area(self):
+        """Estimated Total Module Area [m2]"""
+        if self.approx_nominal_efficiency == 0:
+            raise ValueError("approx_nominal_efficiency cannot be zero.")
+        return self._system_model.SystemDesign.system_capacity / self.approx_nominal_efficiency
 
     @property
     def capacity_factor(self) -> float:

--- a/hopp/simulation/technologies/pv/pv_plant.py
+++ b/hopp/simulation/technologies/pv/pv_plant.py
@@ -33,6 +33,7 @@ class PVConfig(BaseClass):
             - an object representing a `CustomFinancialModel` or `Singleowner.Singleowner` instance
 
         dc_degradation: Annual DC degradation for lifetime simulations [%/year]
+        approx_nominal_efficiency: approx nominal efficiency depends on module type (standard crystalline silicon 19%, premium 21%, thin film 18%) [decimal]
     """
     system_capacity_kw: float = field(validator=gt_zero)
 
@@ -41,6 +42,7 @@ class PVConfig(BaseClass):
     layout_model: Optional[Union[dict, PVLayout]] = field(default=None)
     fin_model: Optional[Union[str, dict, FinancialModelType]] = field(default=None)
     dc_degradation: Optional[List[float]] = field(default=None)
+    approx_nominal_efficiency: Optional[float] = field(default=0.19)
 
 
 @define
@@ -96,6 +98,11 @@ class PVPlant(PowerSource):
             self.dc_degradation = self.config.dc_degradation
         else:
             self.dc_degradation = [0]
+        
+        if self.config.approx_nominal_efficiency is not None:
+            self.approx_nominal_efficiency = self.config.approx_nominal_efficiency
+        else:
+            self.approx_nominal_efficiency = 0.19
 
         if layout_model is not None:
             self.layout = layout_model
@@ -144,6 +151,28 @@ class PVPlant(PowerSource):
     def dc_ac_ratio(self, inverter_loading_ratio: float):
         """Sets DC to AC inverter loading ratio [ratio]."""
         self._system_model.SystemDesign.dc_ac_ratio = inverter_loading_ratio
+    
+    @property
+    def module_type(self) -> int:
+        """ Module type: standard, premium, thin film [0/1/2]"""
+        return self._system_model.value("module_type")
+
+    @module_type.setter
+    def module_type(self, solar_module_type: int):
+        """ Sets module type: standard, premium, thin film [0/1/2]"""
+        if 0 <= solar_module_type <= 2:
+            self._system_model.value("module_type", solar_module_type)
+        else:
+            raise ValueError("Invalid module type")
+        if solar_module_type is not None:
+            efficiency_mapping = {0: 0.19, 1: 0.21, 2: 0.18}
+            if solar_module_type in efficiency_mapping:
+                self.approx_nominal_efficiency = efficiency_mapping[solar_module_type]
+            else:
+                raise ValueError("Module type not recognized")
+        else:
+            raise NotImplementedError("Module type not set")
+
 
     @property
     def capacity_factor(self) -> float:

--- a/tests/hopp/test_hybrid.py
+++ b/tests/hopp/test_hybrid.py
@@ -207,7 +207,6 @@ def test_hybrid_pv_only(hybrid_config):
 
     hybrid_plant = hi.system
 
-
     hi.simulate()
 
     aeps = hybrid_plant.annual_energies

--- a/tests/hopp/test_hybrid.py
+++ b/tests/hopp/test_hybrid.py
@@ -212,6 +212,9 @@ def test_hybrid_pv_only(hybrid_config):
 
     aeps = hybrid_plant.annual_energies
     npvs = hybrid_plant.net_present_values
+    cf = hybrid_plant.capacity_factors
+
+    assert cf.hybrid == approx(cf.pv)
 
     assert aeps.pv == approx(9884106.55, 1e-3)
     assert aeps.hybrid == approx(9884106.55, 1e-3)

--- a/tests/hopp/test_pv_source.py
+++ b/tests/hopp/test_pv_source.py
@@ -40,3 +40,20 @@ def test_pv_plant_initialization(site, subtests):
     assert pv_plant.name == "PVPlant"
     assert pv_plant.system_capacity_kw == system_capacity_kw
     assert_array_equal(pv_plant.dc_degradation, [0])
+
+def test_module_type(site, subtests):
+    system_capacity_kw = 100.0
+    config_data = {'system_capacity_kw': system_capacity_kw}
+    config = PVConfig.from_dict(config_data)
+
+    pv_plant = PVPlant(site=site, config=config)
+
+    with subtests.test("initial module type"):
+        assert pv_plant.module_type == 0
+        assert pv_plant.approx_nominal_efficiency == 0.19
+
+    with subtests.test("change module type"):
+        pv_plant.module_type = 2
+        assert pv_plant.approx_nominal_efficiency == 0.18
+
+    

--- a/tests/hopp/test_pv_source.py
+++ b/tests/hopp/test_pv_source.py
@@ -69,3 +69,13 @@ def test_pv_plant_area(site, subtests):
     
     with subtests.test("plant area"):
         assert pv_plant.plant_area == pytest.approx(526.31, 0.1)
+
+def test_pv_plant_mass(site, subtests):
+    system_capacity_kw = 100.0
+    config_data = {'system_capacity_kw': system_capacity_kw}
+    config = PVConfig.from_dict(config_data)
+
+    pv_plant = PVPlant(site=site, config=config)
+
+    with subtests.test("plant mass"):
+        assert pv_plant.plant_mass == pytest.approx(5789.47,0.1)

--- a/tests/hopp/test_pv_source.py
+++ b/tests/hopp/test_pv_source.py
@@ -78,4 +78,4 @@ def test_pv_plant_mass(site, subtests):
     pv_plant = PVPlant(site=site, config=config)
 
     with subtests.test("plant mass"):
-        assert pv_plant.plant_mass == pytest.approx(5789.47,0.1)
+        assert pv_plant.plant_mass == pytest.approx(5789.47,0.01)

--- a/tests/hopp/test_pv_source.py
+++ b/tests/hopp/test_pv_source.py
@@ -56,4 +56,16 @@ def test_module_type(site, subtests):
         pv_plant.module_type = 2
         assert pv_plant.approx_nominal_efficiency == 0.18
 
+    with subtests.test("module type not found"):
+        with pytest.raises(Exception):
+            pv_plant.module_type = 3
+
+def test_pv_plant_area(site, subtests):
+    system_capacity_kw = 100.0
+    config_data = {'system_capacity_kw': system_capacity_kw}
+    config = PVConfig.from_dict(config_data)
+
+    pv_plant = PVPlant(site=site, config=config)
     
+    with subtests.test("plant area"):
+        assert pv_plant.plant_area == pytest.approx(526.31, 0.1)

--- a/tests/hopp/test_pv_source.py
+++ b/tests/hopp/test_pv_source.py
@@ -68,7 +68,7 @@ def test_pv_plant_area(site, subtests):
     pv_plant = PVPlant(site=site, config=config)
     
     with subtests.test("plant area"):
-        assert pv_plant.plant_area == pytest.approx(526.31, 0.1)
+        assert pv_plant.plant_area == pytest.approx(457.94, 0.1)
 
 def test_pv_plant_mass(site, subtests):
     system_capacity_kw = 100.0
@@ -78,4 +78,4 @@ def test_pv_plant_mass(site, subtests):
     pv_plant = PVPlant(site=site, config=config)
 
     with subtests.test("plant mass"):
-        assert pv_plant.plant_mass == pytest.approx(5789.47,0.01)
+        assert pv_plant.plant_mass == pytest.approx(5079.51,0.01)


### PR DESCRIPTION
- Modified pv `capacity_factors` calculation in `HybridSimulation` to ac capacity factor by multiplying system capacity by inverter loading ratio to get kWh (ac) / kW (ac)
- Added getter/setter for `dc_ac_ratio`
- Modified `PVPlant` `capacity_factor` to ac capacity factor calculation compatible with PySAM v3.0.0
- Added pv `plant_area` property
- Added pv `plant_mass` property
- Updated tests