### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/hopp/version.py
+++ b/hopp/version.py
@@ -1,3 +1,3 @@
 """HOPP Version Number"""
 
-__version__ = "1.0.0"
+__version__ = "2.0.0"


### PR DESCRIPTION
There was a mistake in uploading v0.1 which caused PyPI to consider it v1.0, so we're bumping the version to be v2.0.0. The code remains unchanged.