### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,82 @@
+---
+name: Bug report
+about: Report a bug to help us improve
+title: 'Bug report'
+labels: "Type: Bug"
+---
+
+<!--
+IMPORTANT NOTES
+
+Thank you for taking the time to report a bug. If you aren't certain whether an issue
+is a bug, please first open a Discussion. Before submitting, please reread your
+description to ensure that other readers can reasonably understand the issue
+you're facing and the impact on your workflow or results.
+
+This form is written in GitHub's Markdown format. For a reference on this type
+of syntax, see GitHub's documentation:
+https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
+
+This template contains guidance for your submission within the < ! - -, - - > blocks.
+These are comments in HTML syntax and will not appear in the submission.
+Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.
+
+When including code snippets, please paste the text itself and wrap the code block with
+ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
+For example, Python code should be wrapped in ticks like this:
+```python
+def a_func():
+    return 1
+
+a = 1
+b = a_func()
+print(a + b)
+```
+This is preferred over screen shots since it is searchable and others can copy/paste
+the text to run it.
+-->
+
+# Add meaningful title here
+<!--
+A clear and concise description of the bug including what happened
+and what you expected to happen.
+-->
+
+## How to reproduce
+<!--
+Describe how another person with no context can recreate this issue.
+It is typically very helpful to reduce the problem as much as possible
+and share a minimum working example. See the note above on including
+code as text rather than screenshots.
+-->
+
+## Relevant output
+<!--
+Include any output, plots, or other means of communication here to add context to the problem.
+ -->
+
+## HOPP version
+<!--
+Share your HOPP version and how you installed it. You can print the HOPP version from
+a Python REPL or script with these commands:
+```python
+import hopp
+print(hopp.__version__)
+```
+ -->
+
+## System Information
+<!-- Add your information here. -->
+ - OS: <e.g. Ubuntu 20.04 or macOS 10.12>
+ - Python version: <Result of `python --version`>
+ - Library versions
+   - Results of `pip freeze`, for example
+   - FLORIS
+   - matplotlib
+   - NREL-PySAM
+   - numpy
+   - numexpr
+   - orbit-nrel
+   - pandas
+   - scipy
+   - shapely

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Usage question
+    url: https://github.com/NREL/hopp/discussions
+    about: Have any questions about using HOPP? Post in Discussions to engage with the NREL team and HOPP community.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,57 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'Feature request'
+labels: 'Type: Enhancement'
+---
+
+<!--
+IMPORTANT NOTES
+
+Thank you for taking the time to suggest a feature. Before submitting,
+please reread your description to ensure that other readers can reasonably
+understand the motivation and proposed solution.
+
+This form is written in GitHub's Markdown format. For a reference on this type
+of syntax, see GitHub's documentation:
+https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
+
+This template contains guidance for your submission within the < ! - -, - - > blocks.
+These are comments in HTML syntax and will not appear in the submission.
+Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.
+
+When including code snippets, please paste the text itself and wrap the code block with
+ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
+For example, Python code should be wrapped in ticks like this:
+```python
+def a_func():
+    return 1
+
+a = 1
+b = a_func()
+print(a + b)
+```
+This is preferred over screen shots since it is searchable and others can copy/paste
+the text to run it.
+-->
+
+# Add meaningful title here
+<!--
+High level description of the feature request including motivation and background.
+-->
+
+## Proposed solution
+<!--
+Here's an opportunity to prototype a feature. Please include pseudocode, images, or
+any other visual aids to communicate the idea.
+-->
+
+## Alternatives considered
+<!--
+Describe workarounds or alternatives even if hacky or incomplete.
+-->
+
+## Additional context
+<!--
+Optional. Provide anything else that helps to communicate the idea here.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,76 @@
+
+<!--
+IMPORTANT NOTES
+
+Is this pull request ready to be merged?
+- Do the existing tests pass and new tests added for new code?
+- Is all development in a state where you are proud to share it with others and
+  willing to ask other people to take the time to review it?
+- Is it documented in such a way that a review can reasonably understand what you've
+  done and why you've done it? Can other users understand how to use your changes?
+If not but opening the pull request will facilitate development, make it a "draft" pull request
+
+This form is written in GitHub's Markdown format. For a reference on this type
+of syntax, see GitHub's documentation:
+https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
+
+This template contains guidance for your submission within the < ! - -, - - > blocks.
+These are comments in HTML syntax and will not appear in the submission.
+Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.
+
+When including code snippets, please paste the text itself and wrap the code block with
+ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
+For example, Python code should be wrapped in ticks like this:
+```python
+def a_func():
+    return 1
+
+a = 1
+b = a_func()
+print(a + b)
+```
+This is preferred over screen shots since it is searchable and others can copy/paste
+the text to run it.
+-->
+
+
+# Add meaningful title here
+<!--
+Be sure to title your pull request so that readers can scan through the list of PR's and understand
+what this one involves. It should be a few well selected words to get the point across. If you have
+a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
+Keep in mind that the title will be automatically included in the release notes.
+-->
+Describe your feature here.
+
+## Related issue
+<!--
+If one exists, link to a related GitHub Issue.
+-->
+
+## Impacted areas of the software
+<!--
+List any modules or other areas which should be impacted by this pull request. This helps to
+determine the verification tests.
+-->
+
+## Additional supporting information
+<!--
+Add any other context about the problem here.
+-->
+
+## Test results, if applicable
+<!--
+Add the results from unit tests and regression tests here along with justification for any
+failing test cases.
+-->
+
+<!--
+__ For NREL use __
+Release checklist:
+- Update the version in
+    - [ ] README.md
+    - [ ] hopp/VERSION
+- [ ] Verify docs builds correctly
+- [ ] Create a tag in the NREL/HOPP repository
+-->

--- a/hopp/version.py
+++ b/hopp/version.py
@@ -1,3 +1,1 @@
-"""HOPP Version Number"""
-
-__version__ = "2.0.0"
+2.0.0

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,17 @@ from setuptools import setup, find_packages
 import re
 
 
-version = {}
+# Package meta-data.
+NAME = "HOPP"
+DESCRIPTION = "Hybrid Systems Optimization and Performance Platform."
+URL = "https://github.com/NREL/HOPP"
+EMAIL = "dguittet@nrel.gov"
+AUTHOR = "NREL"
+REQUIRES_PYTHON = ">=3.8.0"
 
-with open("hopp/version.py") as fp:
-    exec(fp.read(), version)
+ROOT = Path(__file__).parent
+with open(ROOT / "hopp" / "version.py") as version_file:
+    VERSION = version_file.read().strip()
 
 # Get package data
 base_path = Path("hopp")
@@ -27,16 +34,16 @@ package_data = {
 }
 
 setup(
-    name='HOPP',
-    version=version['__version__'],
-    url='https://github.com/NREL/HOPP',
-    description='Hybrid Systems Optimization and Performance Platform',
+    name=NAME,
+    version=VERSION,
+    url=URL,
+    description=DESCRIPTION,
     long_description=(base_path.parent / "RELEASE.md").read_text(),
     long_description_content_type='text/markdown',
     license='BSD 3-Clause',
-    author='NREL',
-    author_email='dguittet@nrel.gov',
-    python_requires='>=3.8',
+    author=AUTHOR,
+    author_email=EMAIL,
+    python_requires=REQUIRES_PYTHON,
     packages=find_packages(),
     package_data=package_data,
     include_package_data=True,


### PR DESCRIPTION
# Add GitHub templates for Pull Requests, Issues, and Feature Requests
This PR adds templates to guide users on what information they should provide when making pull requests, identifying issues/bugs, or requesting new features. This is modeled after the templates used in NREL's FLORIS repoistory. This PR models the new template. Also, updates to the handling of the version number were made for clear formatting of the version via `hopp.__version__`.

## Related issue
None.

## Impacted areas of the software
`version.py`
`.github/`

## Additional supporting information
The updates to the version handling now return just the version number when requested using the code below, as suggested in the new templates:

```
>>> import hopp
>>> print(hopp.__version__)
2.0.0
```

Previously, the came code would produce:

```
>>> import hopp
>>> print(hopp.__version__)
"""HOPP Version Number"""

__version__ = "2.0.0"
```

## Test results, if applicable
All tests are passing.
