### PR TITLE
Make cost_info om parameters override values from the fin_model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,21 @@ ENV/
 *.gz
 *.db-wal
 
+# GreenHEART structure specific
+tests/greenheart/data/*
+tests/greenheart/output.txt 
+tests/greenheart/test_hydrogen/data/*
+tests/greenheart/test_hydrogen/output.txt 
+hopp/simulation/resource_files/*/*.csv
+hopp/simulation/resource_files/*/*.srw
+examples/reference_plants/*/output/*
+*speed_dir_data.csv
+examples/greenheart/*/data
+examples/greenheart/*/figures
+tests/greenheart/reports/
+tests/greenheart/test_hydrogen/output/
+tests/hopp/data/
+tests/reports/
+tests/data/
+tests/resource_files/
+tests/test_dump.txt

--- a/examples/reference_plants/01-onshore-steel-mn/onshore-steel-mn.py
+++ b/examples/reference_plants/01-onshore-steel-mn/onshore-steel-mn.py
@@ -44,16 +44,6 @@ if __name__ == "__main__":
         output_level=7,
     )
 
-    config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][
-        0
-    ] = config.hopp_config["config"]["cost_info"]["wind_om_per_kw"]
-    config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][
-        0
-    ] = config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
-    config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"][
-        "om_batt_fixed_cost"
-    ] = config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
-
     lcoe, lcoh, steel_finance, _ = run_simulation(config)
 
     print("LCOE: ", lcoe * 1e3, "[$/MWh]")

--- a/examples/reference_plants/02-onshore-ammonia-tx/onshore-ammonia-tx.py
+++ b/examples/reference_plants/02-onshore-ammonia-tx/onshore-ammonia-tx.py
@@ -44,16 +44,6 @@ if __name__ == "__main__":
         output_level=7,
     )
 
-    config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][
-        0
-    ] = config.hopp_config["config"]["cost_info"]["wind_om_per_kw"]
-    config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][
-        0
-    ] = config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
-    config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"][
-        "om_batt_fixed_cost"
-    ] = config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
-
     lcoe, lcoh, _, ammonia_finance = run_simulation(config)
 
     print("LCOE: ", lcoe * 1e3, "[$/MWh]")

--- a/examples/reference_plants/03-offshore-hydrogen-gom/offshore-hydrogen-gom.py
+++ b/examples/reference_plants/03-offshore-hydrogen-gom/offshore-hydrogen-gom.py
@@ -50,13 +50,6 @@ if __name__ == "__main__":
         output_level=5,
     )
 
-    config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][
-        0
-    ] = config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
-    config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"][
-        "om_batt_fixed_cost"
-    ] = config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
-
     lcoe, lcoh, _, _ = run_simulation(config)
 
     print("LCOE: ", lcoe * 1e3, "[$/MWh]")

--- a/examples/reference_plants/04-offshore-hydrogen-ny/offshore-hydrogen-ny.py
+++ b/examples/reference_plants/04-offshore-hydrogen-ny/offshore-hydrogen-ny.py
@@ -50,13 +50,6 @@ if __name__ == "__main__":
         output_level=5,
     )
 
-    config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][
-        0
-    ] = config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
-    config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"][
-        "om_batt_fixed_cost"
-    ] = config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
-
     lcoe, lcoh, _, _ = run_simulation(config)
 
     print("LCOE: ", lcoe * 1e3, "[$/MWh]")

--- a/examples/reference_plants/05-offshore-hydrogen-ca/offshore-hydrogen-ca.py
+++ b/examples/reference_plants/05-offshore-hydrogen-ca/offshore-hydrogen-ca.py
@@ -50,13 +50,6 @@ if __name__ == "__main__":
         output_level=5,
     )
 
-    config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][
-        0
-    ] = config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
-    config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"][
-        "om_batt_fixed_cost"
-    ] = config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
-
     lcoe, lcoh, _, _ = run_simulation(config)
 
     print("LCOE: ", lcoe * 1e3, "[$/MWh]")

--- a/greenheart/simulation/greenheart_simulation.py
+++ b/greenheart/simulation/greenheart_simulation.py
@@ -213,6 +213,49 @@ def run_simulation(config: GreenHeartSimulationConfig):
     else:
         wind_cost_results = None
         
+    # override individual fin_model values with cost_info values
+    if (
+        config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][0]
+        != config.hopp_config["config"]["cost_info"]["wind_om_per_kw"]
+    ):
+        config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][
+        0
+        ] = config.hopp_config["config"]["cost_info"]["wind_om_per_kw"]
+
+        om_fixed_wind_fin_model = config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][0]
+        wind_om_per_kw =  config.hopp_config["config"]["cost_info"]["wind_om_per_kw"]
+        warnings.warn(f"'om_fixed' in the wind `fin_model` was {om_fixed_wind_fin_model}, but 'wind_om_per_kw' in" 
+                f"`cost_info` was {wind_om_per_kw}. The 'om_fixed' value in the wind `fin_model`"
+                "is being overwritten with the value from the `cost_info`", UserWarning)
+    if (
+        config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][0] 
+        != config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
+    ):
+        config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][
+            0
+        ] = config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
+
+        om_fixed_pv_fin_model = config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][0]
+        pv_om_per_kw =  config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
+        warnings.warn(f"'om_fixed' in the pv `fin_model` was {om_fixed_pv_fin_model}, but 'pv_om_per_kw' in" 
+                f"`cost_info` was {pv_om_per_kw}. The 'om_fixed' value in the pv `fin_model`"
+                "is being overwritten with the value from the `cost_info`", UserWarning)
+
+    if (
+        config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"][
+            "om_batt_fixed_cost"
+        ] != config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
+    ):
+        config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"][
+            "om_batt_fixed_cost"
+        ] = config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
+
+        om_batt_fixed_cost = config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"]["om_batt_fixed_cost"]
+        battery_om_per_kw =  config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
+        warnings.warn(f"'om_batt_fixed_cost' in the battery `fin_model` was {om_batt_fixed_cost}, but 'battery_om_per_kw' in" 
+                f"`cost_info` was {battery_om_per_kw}. The 'om_batt_fixed_cost' value in the battery `fin_model`"
+                "is being overwritten with the value from the `cost_info`", UserWarning)
+
     # setup HOPP model
     hopp_config, hopp_site = he_hopp.setup_hopp(
         config.hopp_config,

--- a/greenheart/simulation/greenheart_simulation.py
+++ b/greenheart/simulation/greenheart_simulation.py
@@ -214,8 +214,9 @@ def run_simulation(config: GreenHeartSimulationConfig):
         wind_cost_results = None
         
     # override individual fin_model values with cost_info values
-    if (
-        config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][0]
+    if ("wind" in config.hopp_config["technologies"]) \
+        and ("wind_om_per_kw" in config.hopp_config["config"]["cost_info"]) \
+        and (config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][0]
         != config.hopp_config["config"]["cost_info"]["wind_om_per_kw"]
     ):
         config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][
@@ -227,8 +228,10 @@ def run_simulation(config: GreenHeartSimulationConfig):
         warnings.warn(f"'om_fixed' in the wind `fin_model` was {om_fixed_wind_fin_model}, but 'wind_om_per_kw' in" 
                 f"`cost_info` was {wind_om_per_kw}. The 'om_fixed' value in the wind `fin_model`"
                 "is being overwritten with the value from the `cost_info`", UserWarning)
-    if (
-        config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][0] 
+        
+    if ("pv" in config.hopp_config["technologies"]) \
+        and ("pv_om_per_kw" in config.hopp_config["config"]["cost_info"]) \
+        and (config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][0] 
         != config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
     ):
         config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][
@@ -241,8 +244,9 @@ def run_simulation(config: GreenHeartSimulationConfig):
                 f"`cost_info` was {pv_om_per_kw}. The 'om_fixed' value in the pv `fin_model`"
                 "is being overwritten with the value from the `cost_info`", UserWarning)
 
-    if (
-        config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"][
+    if ("battery" in config.hopp_config["technologies"]) \
+        and ("battery_om_per_kw" in config.hopp_config["config"]["cost_info"]) \
+        and (config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"][
             "om_batt_fixed_cost"
         ] != config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
     ):

--- a/tests/greenheart/test_hydrogen/input_files/plant/hopp_config.yaml
+++ b/tests/greenheart/test_hydrogen/input_files/plant/hopp_config.yaml
@@ -47,4 +47,4 @@ config:
     battery_dispatch: load_following_heuristic #heuristic
   cost_info:
     wind_installed_cost_mw: 3526000 # based on 2023 ATB moderate case for offshore wind
-    wind_om_per_kw: 104.271 # based on 2023 ATB moderate case for offshore wind
+    # wind_om_per_kw: 104.271 # based on 2023 ATB moderate case for offshore wind

--- a/tests/greenheart/test_hydrogen/test_greenheart_system.py
+++ b/tests/greenheart/test_hydrogen/test_greenheart_system.py
@@ -200,6 +200,20 @@ def test_simulation_wind_wave_solar_battery(subtests):
         # TODO base this test value on something. Currently just based on output at writing.
         assert lcoe == approx(0.12936583137325117)  
 
+    with subtests.test("wind_om_per_kw conflict raise warning"):
+        config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][0] = 1.0
+        with warns(UserWarning, match=f"The 'om_fixed' value in the wind `fin_model`"):
+            lcoe, lcoh, _, hi = run_simulation(config)
+    
+    with subtests.test("pv_om_per_kw conflict raise warning"):
+        config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][0] = 1.0
+        with warns(UserWarning, match=f"The 'om_fixed' value in the pv `fin_model`"):
+            lcoe, lcoh, _, hi = run_simulation(config)
+
+    with subtests.test("battery_om_per_kw conflict raise warning"):
+        config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"]["om_batt_fixed_cost"] = 1.0
+        with warns(UserWarning, match=f"The 'om_batt_fixed_cost' value in the battery `fin_model`"):
+            lcoe, lcoh, _, hi = run_simulation(config)
 
 def test_simulation_wind_onshore(subtests):
 

--- a/tests/greenheart/test_hydrogen/test_greenheart_system.py
+++ b/tests/greenheart/test_hydrogen/test_greenheart_system.py
@@ -59,6 +59,8 @@ filename_hopp_config_wind_wave_solar_battery = os.path.join(
         orbit_library_path, f"plant/hopp_config_wind_wave_solar_battery.yaml"
 )
 
+rtol = 1E-5
+
 def test_simulation_wind(subtests):
     config = GreenHeartSimulationConfig(
         filename_hopp_config=filename_hopp_config,
@@ -133,11 +135,11 @@ def test_simulation_wind_wave(subtests):
 
     # TODO base this test value on something
     with subtests.test("lcoh"):
-        assert lcoh == approx(8.133894926897252)
+        assert lcoh == approx(8.133894926897252, rel=rtol)
 
     # prior to 20240207 value was approx(0.11051228251811765) # TODO base this test value on something
     with subtests.test("lcoe"):
-        assert lcoe == approx(0.12887769358919945)
+        assert lcoe == approx(0.12887769358919945, rel=rtol)
 
 
 def test_simulation_wind_wave_solar(subtests):
@@ -163,12 +165,12 @@ def test_simulation_wind_wave_solar(subtests):
     # prior to 20240207 value was approx(10.823798551850347)
     # TODO base this test value on something. Currently just based on output at writing.
     with subtests.test("lcoh"):
-        assert lcoh == approx(12.597232748295273)
+        assert lcoh == approx(12.597232748295273, rel=rtol)
 
     # prior to 20240207 value was approx(0.11035426429749774)
     # TODO base this test value on something. Currently just based on output at writing.
     with subtests.test("lcoe"):
-        assert lcoe == approx(0.12868090262684384)
+        assert lcoe == approx(0.12868090262684384, rel=rtol)
 
 
 def test_simulation_wind_wave_solar_battery(subtests):
@@ -193,12 +195,12 @@ def test_simulation_wind_wave_solar_battery(subtests):
 
     with subtests.test("lcoh"):
         # TODO base this test value on something. Currently just based on output at writing.
-        assert lcoh == approx(16.984071652636903)
+        assert lcoh == approx(16.984071652636903, rel=rtol)
 
     # TODO base this test value on something. Currently just based on output at writing.
     with subtests.test("lcoe"):
         # TODO base this test value on something. Currently just based on output at writing.
-        assert lcoe == approx(0.12936583137325117)  
+        assert lcoe == approx(0.12936583137325117, rel=rtol)  
 
     with subtests.test("wind_om_per_kw conflict raise warning"):
         config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][0] = 1.0
@@ -242,11 +244,11 @@ def test_simulation_wind_onshore(subtests):
 
     # TODO base this test value on something
     with subtests.test("lcoh"):
-        assert lcoh == approx(3.040736244214041)  
+        assert lcoh == approx(3.040736244214041, rel=rtol)  
 
     # TODO base this test value on something
     with subtests.test("lcoe"):
-        assert lcoe == approx(0.034869608896094494)
+        assert lcoe == approx(0.034869608896094494, rel=rtol)
 
 
 def test_simulation_wind_onshore_steel_ammonia(subtests):
@@ -278,23 +280,23 @@ def test_simulation_wind_onshore_steel_ammonia(subtests):
 
     # TODO base this test value on something
     with subtests.test("lcoh"):
-        assert lcoh == approx(3.040736244214041)
+        assert lcoh == approx(3.040736244214041, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("lcoe"):
-        assert lcoe == approx(0.034869649135212274)
+        assert lcoe == approx(0.034869649135212274, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("steel_finance"):
         lcos_expected = 1348.5863267221866
 
-        assert steel_finance.sol.get("price") == approx(lcos_expected)
+        assert steel_finance.sol.get("price") == approx(lcos_expected, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("ammonia_finance"):
         lcoa_expected = 1.0419316870652462
 
-        assert ammonia_finance.sol.get("price") == approx(lcoa_expected)
+        assert ammonia_finance.sol.get("price") == approx(lcoa_expected, rel=rtol)
 
 def test_simulation_wind_battery_pv_onshore_steel_ammonia(subtests):
 
@@ -335,23 +337,23 @@ def test_simulation_wind_battery_pv_onshore_steel_ammonia(subtests):
 
     # TODO base this test value on something
     with subtests.test("lcoh"):
-        assert lcoh == approx(3.0191128494981223)
+        assert lcoh == approx(3.0191128494981223, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("lcoe"):
-        assert lcoe == approx(0.034676133587257206)
+        assert lcoe == approx(0.034676133587257206, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("steel_finance"):
         lcos_expected = 1340.641495821553
 
-        assert steel_finance.sol.get("price") == approx(lcos_expected)
+        assert steel_finance.sol.get("price") == approx(lcos_expected, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("ammonia_finance"):
         lcoa_expected = 1.0405052843769131
 
-        assert ammonia_finance.sol.get("price") == approx(lcoa_expected)
+        assert ammonia_finance.sol.get("price") == approx(lcoa_expected, rel=rtol)
 
 def test_utilities(subtests):
     with subtests.test("`visualize_plant()` only works with the 'floris' wind model"):


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Override fin_model om costs with values in the cost_info portion of the HOPP config file
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
This PR makes sure that om fixed values from cost_info take precedence over the om_fixed values in the fin_model for wind, battery, and PV. If values are overridden, then warnings are raised.

## Related issue
<!--
If one exists, link to a related GitHub Issue.
-->
This PR is related to issue #299 

## Impacted areas of the software
<!--
List any modules or other areas which should be impacted by this pull request. This helps to
determine the verification tests.
-->
greenheart_simulation.py, along with related tests and examples.

## Additional supporting information
<!--
Add any other context about the problem here.
-->

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] hopp/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/HOPP repository
-->
