### PR TITLE
O&M Technologies Bug

### DIFF
--- a/examples/reference_plants/01-onshore-steel-mn/input/plant/default_fin_config.yaml
+++ b/examples/reference_plants/01-onshore-steel-mn/input/plant/default_fin_config.yaml
@@ -8,12 +8,12 @@ battery_system:
   batt_meter_position: 0
 system_costs:
   om_fixed:
-    - 1
+    - 0
   om_production:
-    - 2
+    - 0
   om_capacity:
     - 0
-  om_batt_fixed_cost: 42.888
+  om_batt_fixed_cost: 0
   om_batt_variable_cost:
     - 0
   om_batt_capacity_cost: 0

--- a/examples/reference_plants/02-onshore-ammonia-tx/input/plant/default_fin_config.yaml
+++ b/examples/reference_plants/02-onshore-ammonia-tx/input/plant/default_fin_config.yaml
@@ -8,12 +8,12 @@ battery_system:
   batt_meter_position: 0
 system_costs:
   om_fixed:
-    - 1
+    - 0
   om_production:
-    - 2
+    - 0
   om_capacity:
     - 0
-  om_batt_fixed_cost: 42.888
+  om_batt_fixed_cost: 0
   om_batt_variable_cost:
     - 0
   om_batt_capacity_cost: 0

--- a/examples/reference_plants/03-offshore-hydrogen-gom/input/plant/default_fin_config.yaml
+++ b/examples/reference_plants/03-offshore-hydrogen-gom/input/plant/default_fin_config.yaml
@@ -8,12 +8,12 @@ battery_system:
   batt_meter_position: 0
 system_costs:
   om_fixed:
-    - 1
+    - 0
   om_production:
-    - 2
+    - 0
   om_capacity:
     - 0
-  om_batt_fixed_cost: 42.888
+  om_batt_fixed_cost: 0
   om_batt_variable_cost:
     - 0
   om_batt_capacity_cost: 0

--- a/examples/reference_plants/04-offshore-hydrogen-ny/input/plant/default_fin_config.yaml
+++ b/examples/reference_plants/04-offshore-hydrogen-ny/input/plant/default_fin_config.yaml
@@ -8,12 +8,12 @@ battery_system:
   batt_meter_position: 0
 system_costs:
   om_fixed:
-    - 1
+    - 0
   om_production:
-    - 2
+    - 0
   om_capacity:
     - 0
-  om_batt_fixed_cost: 42.888
+  om_batt_fixed_cost: 0
   om_batt_variable_cost:
     - 0
   om_batt_capacity_cost: 0

--- a/examples/reference_plants/05-offshore-hydrogen-ca/input/plant/default_fin_config.yaml
+++ b/examples/reference_plants/05-offshore-hydrogen-ca/input/plant/default_fin_config.yaml
@@ -8,12 +8,12 @@ battery_system:
   batt_meter_position: 0
 system_costs:
   om_fixed:
-    - 1
+    - 0
   om_production:
-    - 2
+    - 0
   om_capacity:
     - 0
-  om_batt_fixed_cost: 42.888
+  om_batt_fixed_cost: 0
   om_batt_variable_cost:
     - 0
   om_batt_capacity_cost: 0

--- a/greenheart/simulation/greenheart_simulation.py
+++ b/greenheart/simulation/greenheart_simulation.py
@@ -323,49 +323,52 @@ def setup_greenheart_simulation(config: GreenHeartSimulationConfig):
     # override individual fin_model values with cost_info values
     if ("wind" in config.hopp_config["technologies"]) \
         and ("wind_om_per_kw" in config.hopp_config["config"]["cost_info"]) \
-        and (np.any(config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"] \
-        != config.hopp_config["config"]["cost_info"]["wind_om_per_kw"])):
+        and (config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_capacity"][0] \
+        != config.hopp_config["config"]["cost_info"]["wind_om_per_kw"]):
 
-        for i in range(len(config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"])):
+        for i in range(len(config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_capacity"])):
             config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][i] = \
             config.hopp_config["config"]["cost_info"]["wind_om_per_kw"]
 
-            om_fixed_wind_fin_model = config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][i]
+            om_fixed_wind_fin_model = config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_capacity"][i]
             wind_om_per_kw =  config.hopp_config["config"]["cost_info"]["wind_om_per_kw"]
-            warnings.warn(f"'om_fixed[{i}]' in the wind 'fin_model' was {om_fixed_wind_fin_model}, but 'wind_om_per_kw' in" 
-                    f"'cost_info' was {wind_om_per_kw}. The 'om_fixed' value in the wind 'fin_model'"
+            warnings.warn(f"'om_capacity[{i}]' in the wind 'fin_model' was {om_fixed_wind_fin_model}, but 'wind_om_per_kw' in" 
+                    f"'cost_info' was {wind_om_per_kw}. The 'om_capacity' value in the wind 'fin_model'"
                     "is being overwritten with the value from the 'cost_info'", UserWarning)
         
         
     if ("pv" in config.hopp_config["technologies"]) \
         and ("pv_om_per_kw" in config.hopp_config["config"]["cost_info"]) \
-        and (config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][0] 
+        and (config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_capacity"][0] 
         != config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
     ):
-        for i in range(len(config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"])):
-            config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][i] = \
+        for i in range(len(config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_capacity"])):
+            config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_capacity"][i] = \
             config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
 
-            om_fixed_pv_fin_model = config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][i]
+            om_fixed_pv_fin_model = config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_capacity"][i]
             pv_om_per_kw =  config.hopp_config["config"]["cost_info"]["pv_om_per_kw"]
-            warnings.warn(f"'om_fixed[{i}]' in the pv 'fin_model' was {om_fixed_pv_fin_model}, but 'pv_om_per_kw' in" 
-                    f"'cost_info' was {pv_om_per_kw}. The 'om_fixed' value in the pv 'fin_model'"
+            warnings.warn(f"'om_capacity[{i}]' in the pv 'fin_model' was {om_fixed_pv_fin_model}, but 'pv_om_per_kw' in" 
+                    f"'cost_info' was {pv_om_per_kw}. The 'om_capacity' value in the pv 'fin_model'"
                     "is being overwritten with the value from the 'cost_info'", UserWarning)
 
     if ("battery" in config.hopp_config["technologies"]) \
         and ("battery_om_per_kw" in config.hopp_config["config"]["cost_info"]) \
         and (config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"][
-            "om_batt_fixed_cost"
-        ] != config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
+            "om_capacity"
+        ][0] != config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
     ):
         config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"][
-            "om_batt_fixed_cost"
-        ] = config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
+            "om_capacity"
+        ][i] = config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
 
-        om_batt_fixed_cost = config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"]["om_batt_fixed_cost"]
+        # Use this to set the Production-based O&M amount [$/MWh]
+        # config.hopp_config['technologies']['battery']['fin_model']['system_costs']['om_production'] = 
+
+        om_batt_fixed_cost = config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"]["om_capacity"][i]
         battery_om_per_kw =  config.hopp_config["config"]["cost_info"]["battery_om_per_kw"]
-        warnings.warn(f"'om_batt_fixed_cost' in the battery 'fin_model' was {om_batt_fixed_cost}, but 'battery_om_per_kw' in" 
-                f"'cost_info' was {battery_om_per_kw}. The 'om_batt_fixed_cost' value in the battery 'fin_model'"
+        warnings.warn(f"'om_capacity' in the battery 'fin_model' was {om_batt_fixed_cost}, but 'battery_om_per_kw' in" 
+                f"'cost_info' was {battery_om_per_kw}. The 'om_capacity' value in the battery 'fin_model'"
                 "is being overwritten with the value from the 'cost_info'", UserWarning)
 
     # setup HOPP model

--- a/greenheart/tools/eco/finance.py
+++ b/greenheart/tools/eco/finance.py
@@ -540,9 +540,9 @@ def run_opex(
 
     # battery opex
     if "battery" in hopp_config["technologies"].keys():
-        battery_opex = (np.sum(hopp_results["hybrid_plant"].battery.om_fixed) 
-                        * hopp_config["technologies"]["battery"]["system_capacity_kw"]
-        )
+        battery_opex = hopp_results["hybrid_plant"].battery.om_total_expense[
+            0
+        ]
         if battery_opex < 0.1:
             raise (RuntimeWarning(f"Battery OPEX returned as {battery_opex}"))
     else:

--- a/greenheart/tools/eco/finance.py
+++ b/greenheart/tools/eco/finance.py
@@ -530,9 +530,9 @@ def run_opex(
 
     # solar opex
     if "pv" in hopp_config["technologies"].keys():
-        solar_opex = hopp_results["hybrid_plant"].pv.om_fixed + np.sum(
-            hopp_results["hybrid_plant"].pv.om_variable
-        )
+        solar_opex = hopp_results["hybrid_plant"].pv.om_total_expense[
+            0
+        ]
         if solar_opex < 0.1:
             raise (RuntimeWarning(f"Solar OPEX returned as {solar_opex}"))
     else:
@@ -540,8 +540,8 @@ def run_opex(
 
     # battery opex
     if "battery" in hopp_config["technologies"].keys():
-        battery_opex = hopp_results["hybrid_plant"].battery.om_fixed + np.sum(
-            hopp_results["hybrid_plant"].battery.om_variable
+        battery_opex = (np.sum(hopp_results["hybrid_plant"].battery.om_fixed) 
+                        * hopp_config["technologies"]["battery"]["system_capacity_kw"]
         )
         if battery_opex < 0.1:
             raise (RuntimeWarning(f"Battery OPEX returned as {battery_opex}"))

--- a/hopp/simulation/hybrid_simulation.py
+++ b/hopp/simulation/hybrid_simulation.py
@@ -336,47 +336,51 @@ class HybridSimulation(BaseClass):
         Sets Capacity-based O&M amount for each technology [$/kWcap].
         Sets Production-based O&M amount for each technology [$/MWh].
         """
-        # TODO: Remove??? This doesn't seem to be used.
-        # TODO: fix this error statement it doesn't work
         # om_vals = [pv_om_per_kw, wind_om_per_kw, tower_om_per_kw, trough_om_per_kw, wave_om_per_kw, hybrid_om_per_kw]
         # techs = ["pv", "wind", "tower", "trough", "wave", "hybrid"]
         # om_lengths = {tech + "_om_per_kw" : om_val for om_val, tech in zip(om_vals, techs)}
         # if len(set(om_lengths.values())) != 1 and len(set(om_lengths.values())) is not None:
         #     raise ValueError(f"Length of yearly om cost per kw arrays must be equal. Some lengths of om_per_kw values are different from others: {om_lengths}")
-        if pv_om_per_kw and self.pv:
-            self.pv.om_capacity = pv_om_per_kw
+        if self.pv:
+            if pv_om_per_kw:
+                self.pv.om_capacity = pv_om_per_kw
             if pv_om_per_mwh:
                 self.pv.om_production = pv_om_per_mwh
 
-        if wind_om_per_kw and self.wind:
-            self.wind.om_capacity = wind_om_per_kw
+        if self.wind:
+            if wind_om_per_kw:
+                self.wind.om_capacity = wind_om_per_kw
             if wind_om_per_mwh:
                 self.wind.om_production = wind_om_per_mwh
 
-        if tower_om_per_kw and self.tower:
-            self.tower.om_capacity = tower_om_per_kw
+        if self.tower:
+            if tower_om_per_kw:
+                self.tower.om_capacity = tower_om_per_kw
             if tower_om_per_mwh:
                 self.tower.om_production = tower_om_per_mwh
 
-        if trough_om_per_kw and self.trough:
-            self.trough.om_capacity = trough_om_per_kw
+        if self.trough:
+            if trough_om_per_kw:
+                self.trough.om_capacity = trough_om_per_kw
             if trough_om_per_mwh:
                 self.trough.om_production = trough_om_per_mwh
         
-        if wave_om_per_kw and self.wave:
-            self.wave.om_capacity = wave_om_per_kw
+        if self.wave:
+            if wave_om_per_kw:
+                self.wave.om_capacity = wave_om_per_kw
             if wave_om_per_mwh:
                 self.wave.om_production = wave_om_per_mwh
 
-        if battery_om_per_kw and self.battery:
-            self.battery.om_capacity = battery_om_per_kw
+        if self.battery:
+            if battery_om_per_kw:
+                self.battery.om_capacity = battery_om_per_kw
             if battery_om_per_mwh:
                 self.pv.om_production = battery_om_per_mwh
             
         if hybrid_om_per_kw:
             self.grid.om_capacity = hybrid_om_per_kw
-            if hybrid_om_per_mwh:
-                self.hybrid.om_production = hybrid_om_per_mwh
+        if hybrid_om_per_mwh:
+            self.hybrid.om_production = hybrid_om_per_mwh
 
     def size_from_reopt(self):
         """

--- a/hopp/simulation/hybrid_simulation.py
+++ b/hopp/simulation/hybrid_simulation.py
@@ -287,13 +287,16 @@ class HybridSimulation(BaseClass):
             if "_om_per_kw" in key:
                 om_cost_info.update({key: self.cost_info[key]})
                 keys_to_remove.append(key)
+            if "_om_per_mwh" in key:
+                om_cost_info.update({key: self.cost_info[key]})
+                keys_to_remove.append(key)
         for key in keys_to_remove: self.cost_info.pop(key)
         
         # Default cost calculator, can be overwritten
         self.cost_model = create_cost_calculator(self.interconnect_kw, **self.cost_info or {})
 
         # set O and M costs
-        self.set_om_costs_per_kw(**om_cost_info or {})
+        self.set_om_costs(**om_cost_info or {})
 
         self.outputs_factory = HybridSimulationOutput(self.technologies)
 
@@ -321,12 +324,17 @@ class HybridSimulation(BaseClass):
         if hasattr(cost_calculator, "calculate_total_costs"):
             self.cost_model = cost_calculator
 
-    def set_om_costs_per_kw(self, pv_om_per_kw=None, wind_om_per_kw=None,
+    def set_om_costs(self, pv_om_per_kw=None, wind_om_per_kw=None,
                             tower_om_per_kw=None, trough_om_per_kw=None, 
                             wave_om_per_kw=None, battery_om_per_kw=None,
-                            hybrid_om_per_kw=None):
+                            hybrid_om_per_kw=None,
+                            pv_om_per_mwh=None,wind_om_per_mwh=None,
+                            tower_om_per_mwh=None,trough_om_per_mwh=None,
+                            wave_om_per_mwh=None,battery_om_per_mwh=None,
+                            hybrid_om_per_mwh=None,):
         """
         Sets Capacity-based O&M amount for each technology [$/kWcap].
+        Sets Production-based O&M amount for each technology [$/MWh].
         """
         # TODO: Remove??? This doesn't seem to be used.
         # TODO: fix this error statement it doesn't work
@@ -337,24 +345,38 @@ class HybridSimulation(BaseClass):
         #     raise ValueError(f"Length of yearly om cost per kw arrays must be equal. Some lengths of om_per_kw values are different from others: {om_lengths}")
         if pv_om_per_kw and self.pv:
             self.pv.om_capacity = pv_om_per_kw
+            if pv_om_per_mwh:
+                self.pv.om_production = pv_om_per_mwh
 
         if wind_om_per_kw and self.wind:
             self.wind.om_capacity = wind_om_per_kw
+            if wind_om_per_mwh:
+                self.wind.om_production = wind_om_per_mwh
 
         if tower_om_per_kw and self.tower:
             self.tower.om_capacity = tower_om_per_kw
+            if tower_om_per_mwh:
+                self.tower.om_production = tower_om_per_mwh
 
         if trough_om_per_kw and self.trough:
             self.trough.om_capacity = trough_om_per_kw
+            if trough_om_per_mwh:
+                self.trough.om_production = trough_om_per_mwh
         
         if wave_om_per_kw and self.wave:
             self.wave.om_capacity = wave_om_per_kw
+            if wave_om_per_mwh:
+                self.wave.om_production = wave_om_per_mwh
 
         if battery_om_per_kw and self.battery:
             self.battery.om_capacity = battery_om_per_kw
+            if battery_om_per_mwh:
+                self.pv.om_production = battery_om_per_mwh
             
         if hybrid_om_per_kw:
             self.grid.om_capacity = hybrid_om_per_kw
+            if hybrid_om_per_mwh:
+                self.hybrid.om_production = hybrid_om_per_mwh
 
     def size_from_reopt(self):
         """
@@ -430,6 +452,7 @@ class HybridSimulation(BaseClass):
             ``om_capacity``                   Weighted average by capacities
             ``om_fixed``                      Sum of values
             ``om_variable``                   Weighted average by production of non-negative generators
+            ``om_production``                 Weighted average by production of non-negative generators
             ``degradation``                   Weighted average by production of non-negative generators
             ``ptc_fed_amount``                Weighted average by production (assumes 0 for negative generators)
             ``ptc_fed_escal``                 Weighted average by production (assumes 0 for negative generators)
@@ -558,6 +581,7 @@ class HybridSimulation(BaseClass):
         set_average_for_hybrid("om_capacity", size_ratios)
         set_average_for_hybrid("om_fixed", [1] * len(generators))
         set_average_for_hybrid("om_variable", non_storage_production_ratio)
+        set_average_for_hybrid("om_production", non_storage_production_ratio)
         if 'battery' in self.technologies.keys():
             self.grid.value("om_batt_variable_cost", self.battery.value("om_batt_variable_cost"))
 
@@ -964,6 +988,13 @@ class HybridSimulation(BaseClass):
         Fixed O&M, $/year
         """
         return self._aggregate_financial_output("om_fixed_expense", 1)
+    
+    @property
+    def om_production(self):
+        """
+        Production-based O&M amount, $/MWh
+        """
+        return self._aggregate_financial_output("om_production", 1)
 
     @property
     def om_variable_expenses(self):

--- a/hopp/simulation/technologies/power_source.py
+++ b/hopp/simulation/technologies/power_source.py
@@ -463,6 +463,17 @@ class PowerSource(BaseClass):
             self._financial_model.value("om_batt_capacity_cost", om_capacity_per_kw)
 
     @property
+    def om_production(self):
+        """Production-based O&M amount [$/Mwh]"""
+        return self._financial_model.value("om_production")
+    
+    @om_production.setter
+    def om_production(self, om_production_per_mwh: Sequence):
+        if not array_not_scalar(om_production_per_mwh):
+            om_production_per_mwh = (om_production_per_mwh,)
+        self._financial_model.value("om_production", om_production_per_mwh)
+
+    @property
     def om_fixed(self):
         """Fixed O&M annual amount [$/year]"""
         if self.name != "Battery":

--- a/tests/greenheart/test_greenheart_system.py
+++ b/tests/greenheart/test_greenheart_system.py
@@ -197,30 +197,30 @@ def test_simulation_wind_wave_solar_battery(subtests):
 
     with subtests.test("lcoh"):
         # TODO base this test value on something. Currently just based on output at writing.
-        assert results.lcoh == approx(17.102809848001787, rel=rtol)
+        assert results.lcoh == approx(17.105851423463314, rel=rtol)
 
     # TODO base this test value on something. Currently just based on output at writing.
     with subtests.test("lcoe"):
         # TODO base this test value on something. Currently just based on output at writing.
-        assert results.lcoe == approx(0.12936657762567322, rel=rtol)  
+        assert results.lcoe == approx(0.1294193054583137, rel=rtol)  
 
     with subtests.test("no conflict in om cost does not raise warning"):
         with warnings.catch_warnings():
             warnings.simplefilter("error")
 
     with subtests.test("wind_om_per_kw conflict raise warning"):
-        config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_fixed"][0] = 1.0
-        with warns(UserWarning, match=f"The 'om_fixed' value in the wind 'fin_model'"):
+        config.hopp_config["technologies"]["wind"]["fin_model"]["system_costs"]["om_capacity"][0] = 1.0
+        with warns(UserWarning, match=f"The 'om_capacity' value in the wind 'fin_model'"):
             _ = run_simulation(config)
     
     with subtests.test("pv_om_per_kw conflict raise warning"):
-        config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_fixed"][0] = 1.0
-        with warns(UserWarning, match=f"The 'om_fixed' value in the pv 'fin_model'"):
+        config.hopp_config["technologies"]["pv"]["fin_model"]["system_costs"]["om_capacity"][0] = 1.0
+        with warns(UserWarning, match=f"The 'om_capacity' value in the pv 'fin_model'"):
             _ = run_simulation(config)
 
     with subtests.test("battery_om_per_kw conflict raise warning"):
-        config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"]["om_batt_fixed_cost"] = 1.0
-        with warns(UserWarning, match=f"The 'om_batt_fixed_cost' value in the battery 'fin_model'"):
+        config.hopp_config["technologies"]["battery"]["fin_model"]["system_costs"]["om_capacity"][0] = 1.0
+        with warns(UserWarning, match=f"The 'om_capacity' value in the battery 'fin_model'"):
             _ = run_simulation(config)
 
 def test_simulation_wind_onshore(subtests):
@@ -343,15 +343,15 @@ def test_simulation_wind_battery_pv_onshore_steel_ammonia(subtests):
 
     # TODO base this test value on something
     with subtests.test("lcoh"):
-        assert greenheart_output.lcoh == approx(3.1476029100059995, rel=rtol)
+        assert greenheart_output.lcoh == approx(3.1509756450008752, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("lcoe"):
-        assert greenheart_output.lcoe == approx(0.03470063589149857, rel=rtol)
+        assert greenheart_output.lcoe == approx(0.03476011434910082, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("steel_finance"):
-        lcos_expected = 1349.11151601181
+        lcos_expected = 1349.3364242679354
 
         assert greenheart_output.steel_finance.sol.get("price") == approx(lcos_expected, rel=rtol)
 

--- a/tests/greenheart/test_greenheart_system.py
+++ b/tests/greenheart/test_greenheart_system.py
@@ -172,7 +172,7 @@ def test_simulation_wind_wave_solar(subtests):
     # prior to 20240207 value was approx(0.11035426429749774)
     # TODO base this test value on something. Currently just based on output at writing.
     with subtests.test("lcoe"):
-        assert lcoe == approx(0.1286534909241672, rel=rtol)
+        assert lcoe == approx(0.12865548678206473, rel=rtol)
 
 
 def test_simulation_wind_wave_solar_battery(subtests):
@@ -197,12 +197,12 @@ def test_simulation_wind_wave_solar_battery(subtests):
 
     with subtests.test("lcoh"):
         # TODO base this test value on something. Currently just based on output at writing.
-        assert results.lcoh == approx(17.101171531014003, rel=rtol)
+        assert results.lcoh == approx(17.10585236474601, rel=rtol)
 
     # TODO base this test value on something. Currently just based on output at writing.
     with subtests.test("lcoe"):
         # TODO base this test value on something. Currently just based on output at writing.
-        assert results.lcoe == approx(0.12933817625769398, rel=rtol)  
+        assert results.lcoe == approx(0.12941932177610593, rel=rtol)  
 
     with subtests.test("no conflict in om cost does not raise warning"):
         with warnings.catch_warnings():
@@ -343,15 +343,15 @@ def test_simulation_wind_battery_pv_onshore_steel_ammonia(subtests):
 
     # TODO base this test value on something
     with subtests.test("lcoh"):
-        assert greenheart_output.lcoh == approx(3.1457862169443622, rel=rtol)
+        assert greenheart_output.lcoh == approx(3.1509766887682007, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("lcoe"):
-        assert greenheart_output.lcoe == approx(0.034668598360711525, rel=rtol)
+        assert greenheart_output.lcoe == approx(0.03476013275602302, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("steel_finance"):
-        lcos_expected = 1348.9903712230794
+        lcos_expected = 1349.336493870762
 
         assert greenheart_output.steel_finance.sol.get("price") == approx(lcos_expected, rel=rtol)
 

--- a/tests/greenheart/test_greenheart_system.py
+++ b/tests/greenheart/test_greenheart_system.py
@@ -197,12 +197,12 @@ def test_simulation_wind_wave_solar_battery(subtests):
 
     with subtests.test("lcoh"):
         # TODO base this test value on something. Currently just based on output at writing.
-        assert results.lcoh == approx(17.10585236474601, rel=rtol)
+        assert results.lcoh == approx(17.102809848001787, rel=rtol)
 
     # TODO base this test value on something. Currently just based on output at writing.
     with subtests.test("lcoe"):
         # TODO base this test value on something. Currently just based on output at writing.
-        assert results.lcoe == approx(0.12941932177610593, rel=rtol)  
+        assert results.lcoe == approx(0.12936657762567322, rel=rtol)  
 
     with subtests.test("no conflict in om cost does not raise warning"):
         with warnings.catch_warnings():
@@ -343,21 +343,21 @@ def test_simulation_wind_battery_pv_onshore_steel_ammonia(subtests):
 
     # TODO base this test value on something
     with subtests.test("lcoh"):
-        assert greenheart_output.lcoh == approx(3.1509766887682007, rel=rtol)
+        assert greenheart_output.lcoh == approx(3.1476029100059995, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("lcoe"):
-        assert greenheart_output.lcoe == approx(0.03476013275602302, rel=rtol)
+        assert greenheart_output.lcoe == approx(0.03470063589149857, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("steel_finance"):
-        lcos_expected = 1349.336493870762
+        lcos_expected = 1349.11151601181
 
         assert greenheart_output.steel_finance.sol.get("price") == approx(lcos_expected, rel=rtol)
 
     # TODO base this test value on something
     with subtests.test("ammonia_finance"):
-        lcoa_expected = 1.0404837286893611
+        lcoa_expected = 1.0404837286866984
 
         assert greenheart_output.ammonia_finance.sol.get("price") == approx(lcoa_expected, rel=rtol)
 

--- a/tests/hopp/test_detailed_pv_plant.py
+++ b/tests/hopp/test_detailed_pv_plant.py
@@ -4,17 +4,17 @@ import json
 import pytest
 from pytest import fixture
 
-from hopp.simulation.technologies.pv.detailed_pv_plant import DetailedPVConfig, DetailedPVPlant
-from hopp.simulation.technologies.financial.custom_financial_model import CustomFinancialModel
+from hopp.simulation.technologies.pv.detailed_pv_plant import (
+    DetailedPVConfig,
+    DetailedPVPlant,
+)
+from hopp.simulation.technologies.financial.custom_financial_model import (
+    CustomFinancialModel,
+)
 from hopp.simulation.technologies.layout.pv_layout import PVGridParameters
 from tests.hopp.utils import create_default_site_info, DEFAULT_FIN_CONFIG
 
-config_data = {
-    'system_capacity_kw': 100,
-    'tech_config': {
-        'subarray2_enable': 0
-    }
-}
+config_data = {"system_capacity_kw": 100, "tech_config": {"subarray2_enable": 0}}
 
 
 @fixture
@@ -26,7 +26,25 @@ def test_detailed_pv_plant_initialization(site, subtests):
     """Test simple instantiation (no layout params)."""
     config = DetailedPVConfig.from_dict(config_data)
     pv_plant = DetailedPVPlant(site=site, config=config)
-    assert pv_plant.site == site
+    with subtests.test("Site: lat and lon"):
+        assert pv_plant.site.lat == site.lat
+        assert pv_plant.site.lon == site.lon
+    with subtests.test("Site: elev"):
+        assert pv_plant.site.data["elev"] == site.data["elev"]
+    with subtests.test("Site: year"):
+        assert pv_plant.site.data["year"] == site.data["year"]
+    with subtests.test("Site: tz"):
+        assert pv_plant.site.data["tz"] == site.data["tz"]
+    with subtests.test("Site: site boundaries"):
+        assert (
+            pv_plant.site.data["site_boundaries"]["verts"]
+            == site.data["site_boundaries"]["verts"]
+        )
+    with subtests.test("Site: site boundaries simple"):
+        assert (
+            pv_plant.site.data["site_boundaries"]["verts_simple"]
+            == site.data["site_boundaries"]["verts_simple"]
+        )
     assert pv_plant._financial_model is not None
     assert pv_plant.layout is not None
     assert pv_plant.layout.parameters is None
@@ -36,20 +54,22 @@ def test_detailed_pv_plant_initialization(site, subtests):
 def test_single_subarray_limitation(site):
     """Ensure only one subarray is allowed."""
     config_with_multiple_subarrays = {
-        'system_capacity_kw': 100,
-        'tech_config': {
-            'subarray2_enable': 1
-        }
+        "system_capacity_kw": 100,
+        "tech_config": {"subarray2_enable": 1},
     }
     config = DetailedPVConfig.from_dict(config_with_multiple_subarrays)
-    with pytest.raises(Exception, match=r"Detailed PV plant currently only supports one subarray."):
+    with pytest.raises(
+        Exception, match=r"Detailed PV plant currently only supports one subarray."
+    ):
         DetailedPVPlant(site=site, config=config)
 
 
 def test_processed_assign(site, subtests):
     """Test more detailed instantiation with `tech_config`."""
-    pvsamv1_defaults_file = Path(__file__).absolute().parent / "pvsamv1_basic_params.json"
-    with open(pvsamv1_defaults_file, 'r') as f:
+    pvsamv1_defaults_file = (
+        Path(__file__).absolute().parent / "pvsamv1_basic_params.json"
+    )
+    with open(pvsamv1_defaults_file, "r") as f:
         tech_config = json.load(f)
 
     with subtests.test("With Pvsamv1 configuration file"):
@@ -61,27 +81,29 @@ def test_processed_assign(site, subtests):
 def test_layout_parameters(site):
     """Ensure layout parameters are set properly if provided."""
     config_with_layout_params = {
-        'system_capacity_kw': 100,
-        'layout_params': PVGridParameters(
+        "system_capacity_kw": 100,
+        "layout_params": PVGridParameters(
             x_position=0.5,
             y_position=0.5,
             aspect_power=0,
             gcr=0.5,
             s_buffer=2,
-            x_buffer=2
-        )
+            x_buffer=2,
+        ),
     }
     config = DetailedPVConfig.from_dict(config_with_layout_params)
     pv_plant = DetailedPVPlant(site=site, config=config)
-    assert pv_plant.layout.parameters == config_with_layout_params['layout_params']
+    assert pv_plant.layout.parameters == config_with_layout_params["layout_params"]
 
 
 def test_custom_financial(site):
     """Test with a non-default financial model."""
-    config = DetailedPVConfig.from_dict({
-        'system_capacity_kw': 100,
-        'fin_model': CustomFinancialModel(DEFAULT_FIN_CONFIG),
-    })
+    config = DetailedPVConfig.from_dict(
+        {
+            "system_capacity_kw": 100,
+            "fin_model": CustomFinancialModel(DEFAULT_FIN_CONFIG),
+        }
+    )
     pv_plant = DetailedPVPlant(site=site, config=config)
     assert pv_plant._financial_model is not None
     assert isinstance(pv_plant._financial_model, CustomFinancialModel)

--- a/tests/hopp/test_hybrid.py
+++ b/tests/hopp/test_hybrid.py
@@ -484,7 +484,7 @@ def test_hybrid_pv_only_custom_fin(hybrid_config, subtests):
     hi = HoppInterface(hybrid_config)
 
     hybrid_plant = hi.system
-    hybrid_plant.set_om_costs_per_kw(pv_om_per_kw=20)
+    hybrid_plant.set_om_costs(pv_om_per_kw=20)
 
     hi.simulate()
 
@@ -570,7 +570,7 @@ def test_hybrid_pv_battery_custom_fin(hybrid_config, subtests):
     hybrid_plant = hi.system
     # hybrid_plant.pv.set_overnight_capital_cost(400)
     # hybrid_plant.battery.set_overnight_capital_cost(300,200)
-    hybrid_plant.set_om_costs_per_kw(pv_om_per_kw=20, battery_om_per_kw=30)
+    hybrid_plant.set_om_costs(pv_om_per_kw=20, battery_om_per_kw=30)
 
     hi.simulate()
 
@@ -1462,12 +1462,16 @@ def test_hybrid_financials(hybrid_config):
     Performance from Wind is slightly different from wind-only case because the solar presence modified the wind layout
     """
     technologies = hybrid_config["technologies"]
-    solar_wind_hybrid = {key: technologies[key] for key in ("pv", "wind", "grid")}
+    solar_wind_hybrid = {key: technologies[key] for key in ("pv", "wind","grid")}
     hybrid_config["technologies"] = solar_wind_hybrid
     hi = HoppInterface(hybrid_config)
     hi.system.pv.om_production = 10
+    hi.system.set_om_costs(pv_om_per_kw=30,wind_om_per_mwh=2, battery_om_per_mwh=10)
     hybrid_plant = hi.system
     hybrid_plant
     hi.simulate()
 
     assert hi.system.pv._financial_model.SystemCosts.om_production == hi.system.pv.om_production
+    assert hi.system.om_total_expenses['pv'][1] == approx(248536, rel=5e-2)
+    assert hi.system.om_total_expenses['wind'][1] == approx(430000.0, rel=5e-2)
+

--- a/tests/hopp/test_hybrid.py
+++ b/tests/hopp/test_hybrid.py
@@ -1466,12 +1466,12 @@ def test_hybrid_financials(hybrid_config):
     hybrid_config["technologies"] = solar_wind_hybrid
     hi = HoppInterface(hybrid_config)
     hi.system.pv.om_production = 10
-    hi.system.set_om_costs(pv_om_per_kw=30,wind_om_per_mwh=2, battery_om_per_mwh=10)
+    hi.system.set_om_costs(pv_om_per_kw=30,wind_om_per_mwh=2)
     hybrid_plant = hi.system
     hybrid_plant
     hi.simulate()
 
     assert hi.system.pv._financial_model.SystemCosts.om_production == hi.system.pv.om_production
     assert hi.system.om_total_expenses['pv'][1] == approx(248536, rel=5e-2)
-    assert hi.system.om_total_expenses['wind'][1] == approx(430000.0, rel=5e-2)
+    assert hi.system.om_total_expenses['wind'][1] == approx(493903.4397049556, rel=5e-2)
 

--- a/tests/hopp/test_hybrid.py
+++ b/tests/hopp/test_hybrid.py
@@ -32,6 +32,7 @@ def hybrid_config():
 
     return hybrid_config
 
+
 @fixture
 def site():
     return create_default_site_info()
@@ -226,9 +227,25 @@ def test_hybrid_wave_only(hybrid_config, wavesite, subtests):
         assert hybrid_plant.wave._financial_model.FinancialParameters == approx(
             hybrid_plant.grid._financial_model.FinancialParameters
         )
-    with subtests.test("Revenue"):
-        assert hybrid_plant.wave._financial_model.Revenue == approx(
-            hybrid_plant.grid._financial_model.Revenue
+    with subtests.test("Revenue: ppa price input"):
+        assert hybrid_plant.wave._financial_model.Revenue.ppa_price_input == approx(
+            hybrid_plant.grid._financial_model.Revenue.ppa_price_input
+        )
+    with subtests.test("Revenue: ppa escalation"):
+        assert hybrid_plant.wave._financial_model.Revenue.ppa_escalation == approx(
+            hybrid_plant.grid._financial_model.Revenue.ppa_escalation
+        )
+    with subtests.test("Revenue: ppa multiplier model"):
+        assert (
+            hybrid_plant.wave._financial_model.Revenue.ppa_multiplier_model
+            == approx(hybrid_plant.grid._financial_model.Revenue.ppa_multiplier_model)
+        )
+    with subtests.test("Revenue: ppa price input"):
+        assert (
+            hybrid_plant.wave._financial_model.Revenue.dispatch_factors_ts.all()
+            == approx(
+                hybrid_plant.grid._financial_model.Revenue.dispatch_factors_ts.all()
+            )
         )
     with subtests.test("SystemCosts"):
         assert hybrid_plant.wave._financial_model.SystemCosts == approx(
@@ -411,30 +428,57 @@ def test_hybrid_pv_only(hybrid_config):
     assert npvs.pv == approx(-5121293, 1e3)
     assert npvs.hybrid == approx(-5121293, 1e3)
 
+
 def test_hybrid_pv_only_custom_fin(hybrid_config, subtests):
     solar_only = {
-        'pv': {
-            'system_capacity_kw': 5000,
-            'layout_params': {
-                'x_position': 0.5,
-                'y_position': 0.5,
-                'aspect_power': 0,
-                'gcr': 0.5,
-                's_buffer': 2,
-                'x_buffer': 2,
-               },
-            'dc_degradation': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            'fin_model': DEFAULT_FIN_CONFIG
+        "pv": {
+            "system_capacity_kw": 5000,
+            "layout_params": {
+                "x_position": 0.5,
+                "y_position": 0.5,
+                "aspect_power": 0,
+                "gcr": 0.5,
+                "s_buffer": 2,
+                "x_buffer": 2,
+            },
+            "dc_degradation": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            "fin_model": DEFAULT_FIN_CONFIG,
         },
-        'grid':{
-            'interconnect_kw': interconnection_size_kw,
-            'fin_model': DEFAULT_FIN_CONFIG,
-        }
+        "grid": {
+            "interconnect_kw": interconnection_size_kw,
+            "fin_model": DEFAULT_FIN_CONFIG,
+        },
     }
     hybrid_config["technologies"] = solar_only
     hybrid_config["config"] = {
         "cost_info": {
-            'solar_installed_cost_mw': 400 * 1000,
+            "solar_installed_cost_mw": 400 * 1000,
         }
     }
     hi = HoppInterface(hybrid_config)
@@ -449,49 +493,76 @@ def test_hybrid_pv_only_custom_fin(hybrid_config, subtests):
     cf = hybrid_plant.capacity_factors
 
     with subtests.test("total installed cost"):
-        assert hybrid_plant.pv.total_installed_cost == approx(2000000,1e-3)
+        assert hybrid_plant.pv.total_installed_cost == approx(2000000, 1e-3)
 
     with subtests.test("om cost"):
         assert hybrid_plant.pv.om_capacity == (20,)
 
     with subtests.test("capacity factor"):
         assert cf.hybrid == approx(cf.pv)
-    
+
     with subtests.test("aep"):
         assert aeps.pv == approx(9884106.55, 1e-3)
         assert aeps.hybrid == aeps.pv
 
+
 def test_hybrid_pv_battery_custom_fin(hybrid_config, subtests):
     tech = {
-        'pv': {
-            'system_capacity_kw': 5000,
-            'layout_params': {
-                'x_position': 0.5,
-                'y_position': 0.5,
-                'aspect_power': 0,
-                'gcr': 0.5,
-                's_buffer': 2,
-                'x_buffer': 2,
-               },
-            'dc_degradation': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            'fin_model': DEFAULT_FIN_CONFIG
+        "pv": {
+            "system_capacity_kw": 5000,
+            "layout_params": {
+                "x_position": 0.5,
+                "y_position": 0.5,
+                "aspect_power": 0,
+                "gcr": 0.5,
+                "s_buffer": 2,
+                "x_buffer": 2,
+            },
+            "dc_degradation": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            "fin_model": DEFAULT_FIN_CONFIG,
         },
-          'battery': {
-            'system_capacity_kw': 5000,
-            'system_capacity_kwh': 20000,
-            'fin_model': DEFAULT_FIN_CONFIG
-          },
-        'grid':{
-            'interconnect_kw': interconnection_size_kw,
-            'fin_model': DEFAULT_FIN_CONFIG,
-        }
+        "battery": {
+            "system_capacity_kw": 5000,
+            "system_capacity_kwh": 20000,
+            "fin_model": DEFAULT_FIN_CONFIG,
+        },
+        "grid": {
+            "interconnect_kw": interconnection_size_kw,
+            "fin_model": DEFAULT_FIN_CONFIG,
+        },
     }
     hybrid_config["technologies"] = tech
     hybrid_config["config"] = {
         "cost_info": {
-            'solar_installed_cost_mw': 400 * 1000,
-            'storage_installed_cost_mw': 200 * 1000,
-            'storage_installed_cost_mwh': 300 * 1000
+            "solar_installed_cost_mw": 400 * 1000,
+            "storage_installed_cost_mw": 200 * 1000,
+            "storage_installed_cost_mwh": 300 * 1000,
         }
     }
     hi = HoppInterface(hybrid_config)
@@ -499,7 +570,7 @@ def test_hybrid_pv_battery_custom_fin(hybrid_config, subtests):
     hybrid_plant = hi.system
     # hybrid_plant.pv.set_overnight_capital_cost(400)
     # hybrid_plant.battery.set_overnight_capital_cost(300,200)
-    hybrid_plant.set_om_costs_per_kw(pv_om_per_kw=20,battery_om_per_kw=30)
+    hybrid_plant.set_om_costs_per_kw(pv_om_per_kw=20, battery_om_per_kw=30)
 
     hi.simulate()
 
@@ -508,16 +579,17 @@ def test_hybrid_pv_battery_custom_fin(hybrid_config, subtests):
     cf = hybrid_plant.capacity_factors
 
     with subtests.test("pv total installed cost"):
-        assert hybrid_plant.pv.total_installed_cost == approx(2000000,1e-3)
+        assert hybrid_plant.pv.total_installed_cost == approx(2000000, 1e-3)
 
     with subtests.test("pv om cost"):
         assert hybrid_plant.pv.om_capacity == (20,)
 
     with subtests.test("battery total installed cost"):
-        assert hybrid_plant.battery.total_installed_cost == approx(7000000,1e-3)
+        assert hybrid_plant.battery.total_installed_cost == approx(7000000, 1e-3)
 
     with subtests.test("battery om cost"):
         assert hybrid_plant.battery.om_capacity == (30,)
+
 
 def test_detailed_pv_system_capacity(hybrid_config, subtests):
     with subtests.test(

--- a/tests/hopp/test_hybrid.py
+++ b/tests/hopp/test_hybrid.py
@@ -1456,3 +1456,18 @@ def test_capacity_credit(hybrid_config):
     assert tc.wind[1] == approx(830744, rel=5e-2)
     assert tc.battery[1] == approx(2201850, rel=5e-2)
     assert tc.hybrid[1] == approx(4338902, rel=5e-2)
+
+def test_hybrid_financials(hybrid_config):
+    """
+    Performance from Wind is slightly different from wind-only case because the solar presence modified the wind layout
+    """
+    technologies = hybrid_config["technologies"]
+    solar_wind_hybrid = {key: technologies[key] for key in ("pv", "wind", "grid")}
+    hybrid_config["technologies"] = solar_wind_hybrid
+    hi = HoppInterface(hybrid_config)
+    hi.system.pv.om_production = 10
+    hybrid_plant = hi.system
+    hybrid_plant
+    hi.simulate()
+
+    assert hi.system.pv._financial_model.SystemCosts.om_production == hi.system.pv.om_production


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.
-->


# Fix O&M Technologies Bug
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
Solar and battery O&M was not being converted from the fixed O&M input in `cost_info` in `$/kW-yr` to `$/yr` required for ProFAST calculations. 

- For `pv` change method to use first year of `om_total_expense` output. 
- For `battery` change method to use multiply `om_fixed` and `system_capacity_kw`. Did not include Variable O&M based on [ATB](https://atb.nrel.gov/electricity/2023/utility-scale_battery_storage).

## Related issue
<!--
If one exists, link to a related GitHub Issue.
-->

## Impacted areas of the software
<!--
List any modules or other areas which should be impacted by this pull request. This helps to
determine the verification tests.
-->

## Additional supporting information
<!--
Add any other context about the problem here.
-->

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->

<!--
__ For NREL use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] hopp/VERSION
- [ ] Verify docs builds correctly
- [ ] Create a tag in the NREL/HOPP repository
-->
