### PR TITLE
Bugfix: Remove unused property that could cause recursion loop

### DIFF
--- a/hopp/simulation/technologies/financial/custom_financial_model.py
+++ b/hopp/simulation/technologies/financial/custom_financial_model.py
@@ -393,9 +393,10 @@ class CustomFinancialModel():
     def annual_energy(self) -> float:
         return self.value('annual_energy_pre_curtailment_ac')
     
-    @property
-    def om_total_expense(self) -> float:
-        return self.value('om_total_expense')
+    #below throws a recursion error in debug mode
+    # @property
+    # def om_total_expense(self) -> float:
+    #     return self.value('om_total_expense')
     
     # for compatibility with calls to SingleOwner
     @property


### PR DESCRIPTION
# Remove cost property that can cause recursion loop when accessed

This PR removes the `om_total_expense` property from the custom financial model. This bug was identified and fixed by @elenya-grant when using the python debugger.

## Related issue
None.

## Impacted areas of the software
`simulation/technologies/financial/custom_financial_model.py`

## Additional supporting information
None.

## Test results, if applicable
Tests are passing.
