### PR TITLE
Bug Fix: Correct the display name of the Test PyPI Action

### DIFF
--- a/.github/workflows/publish_to_test_pypi.yml
+++ b/.github/workflows/publish_to_test_pypi.yml
@@ -1,4 +1,4 @@
-name: Upload to PyPi
+name: Upload to Test PyPi
 
 on:
   push:


### PR DESCRIPTION
This PR is a minor fix to the Test PyPI uploader GitHub Action to ensure the displayed name in the Actions tab shows as expected. Previously the PyPI and Test PyPI display name were mistakenly the same.