### PR TITLE
feature: option to load wind and solar resource data from HPC

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,10 @@
 
 # Required
 version: 2
-
+sphinx:
+   # Path to your Sphinx configuration file.
+   configuration: docs/conf.py
+   
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased, TBD
+* Added option and functionality to load wind and solar resource data from NSRDB and Wind Toolkit data files if user-specified.
+* Fixed a bug in site_info that set resource year to 2012 even if otherwise specified.
+
 ## Version 3.1.1, Dec. 18, 2024
 
 * Enhanced PV plant functionality: added tilting solar panel support, improved system design handling, and refined tilt angle calculations.

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -14,6 +14,13 @@ parts:
   chapters:
   - file: api/hopp_interface
   - file: api/site_info
+    sections:
+    - file: api/resource/index
+      sections:
+      - file: api/resource/solar_api
+      - file: api/resource/wind_api
+      - file: api/resource/solar_hpc
+      - file: api/resource/wind_hpc
   - file: api/hybrid_simulation
   - file: api/technology/index
     sections:

--- a/docs/api/resource/index.md
+++ b/docs/api/resource/index.md
@@ -1,0 +1,39 @@
+# Resource Data
+
+These are the primary methods for accessing wind and solar resource data.
+
+- [Solar Resource (API)](resource:solar-resource)
+- [Wind Resource (API)](resource:wind-resource)
+- [Solar Resource (NSRDB Dataset on NREL HPC)](resource:nsrdb-data)
+- [Wind Resource (Wind Toolkit Dataset on NREL HPC)](resource:wtk-data)
+
+## NREL API Keys
+
+An NREL API key is required to use the functionality for [Solar Resource (API)](resource:solar-resource) and [Wind Resource (API)](resource:wind-resource).
+
+An NREL API key can be obtained from [here](https://developer.nrel.gov/signup/).
+
+Once an API key is obtained, create a file ".env" in the HOPP root directory (/path/to/HOPP/.env) that contains the lines:
+
+```bash
+NREL_API_KEY=key
+NREL_API_EMAIL=your.name@email.com
+```
+
+where `key` is your API key and `your.name@email.com` is the email that was used to get the API key.
+
+## NREL HPC Datasets
+
+To load resource data from datasets hosted on NREL's HPC, HOPP must be installed and run from the NREL HPC. Currently, loading resource data from HPC is only enabled for [wind](resource:wtk-data) and [solar](resource:nsrdb-data) resource.
+
+
+(resource:resource-base)=
+## Resource Base Class
+
+Base class for resource data
+
+```{eval-rst}
+.. autoclass:: hopp.simulation.technologies.resource.Resource
+    :members:
+    :exclude-members: copy, plot, _abc_impl
+```

--- a/docs/api/resource/solar_api.md
+++ b/docs/api/resource/solar_api.md
@@ -1,0 +1,10 @@
+(resource:solar-resource)=
+# Solar Resource (API)
+
+By default, solar resource data is downloaded from the NREL Developer Network hosted National Solar Radiation Database (NSRDB) dataset [Physical Solar Model (PSM) v3.2.2](https://developer.nrel.gov/docs/solar/nsrdb/psm3-2-2-download/). Using this functionality requires an NREL API key.
+
+```{eval-rst}
+.. autoclass:: hopp.simulation.technologies.resource.solar_resource.SolarResource
+    :members:
+    :exclude-members: _abc_impl, check_download_dir
+```

--- a/docs/api/resource/solar_hpc.md
+++ b/docs/api/resource/solar_hpc.md
@@ -1,0 +1,11 @@
+(resource:nsrdb-data)=
+# Solar Resource (NSRDB Dataset on NREL HPC)
+
+If enabled, solar resource data can be loaded from the NREL HPC (Kestrel) hosted National Solar Radiation Database (NSRDB) dataset. This functionality leverages the [NREL REsource eXtraction (rex) tool](https://github.com/NREL/rex). Information on NREL HPC file systems and datasets can be found [here](https://nrel.github.io/HPC/Documentation/Systems/Kestrel/Filesystems/#projectfs).
+
+```{eval-rst}
+.. autoclass:: hopp.simulation.technologies.resource.nsrdb_data.HPCSolarData
+    :members:
+    :undoc-members:
+    :exclude-members: _abc_impl, check_download_dir, call_api
+```

--- a/docs/api/resource/wind_api.md
+++ b/docs/api/resource/wind_api.md
@@ -1,0 +1,10 @@
+(resource:wind-resource)=
+# Wind Resource (API)
+
+By default, wind resource data is downloaded from the NREL Developer Network hosted Wind Integration National Dataset (WIND) Toolkit dataset [Wind Toolkit Data - SAM format (srw)](https://developer.nrel.gov/docs/wind/wind-toolkit/wtk-srw-download/). Using this functionality requires an NREL API key.
+
+```{eval-rst}
+.. autoclass:: hopp.simulation.technologies.resource.wind_resource.WindResource
+    :members:
+    :exclude-members: _abc_impl, check_download_dir
+```

--- a/docs/api/resource/wind_hpc.md
+++ b/docs/api/resource/wind_hpc.md
@@ -1,0 +1,11 @@
+(resource:wtk-data)=
+# Wind Resource (Wind Toolkit Dataset on NREL HPC)
+
+If enabled, wind resource data can be loaded from the NREL HPC (Kestrel) hosted Wind Integration National Dataset (WIND) Toolkit dataset. This functionality leverages the [NREL REsource eXtraction (rex) tool](https://github.com/NREL/rex). Information on NREL HPC file systems and datasets can be found [here](https://nrel.github.io/HPC/Documentation/Systems/Kestrel/Filesystems/#projectfs).
+
+```{eval-rst}
+.. autoclass:: hopp.simulation.technologies.resource.wind_toolkit_data.HPCWindData
+    :members:
+    :undoc-members: 
+    :exclude-members: _abc_impl, check_download_dir, call_api
+```

--- a/docs/api/site_info.md
+++ b/docs/api/site_info.md
@@ -1,11 +1,9 @@
-.. _SiteInfo:
-
-
-Hybrid Plant Site Information
-==============================
+# Hybrid Plant Site Information
 
 The purpose of this class is to house all site specific data, e.g., weather data.
 
+```{eval-rst}
 .. autoclass:: hopp.simulation.technologies.sites.SiteInfo
     :members:
     :undoc-members:
+```

--- a/hopp/simulation/technologies/resource/__init__.py
+++ b/hopp/simulation/technologies/resource/__init__.py
@@ -5,3 +5,5 @@ from hopp.simulation.technologies.resource.elec_prices import ElectricityPrices
 from hopp.simulation.technologies.resource.resource import Resource
 from hopp.simulation.technologies.resource.greet_data import GREETData
 from hopp.simulation.technologies.resource.cambium_data import CambiumData
+from hopp.simulation.technologies.resource.nsrdb_data import HPCSolarData
+from hopp.simulation.technologies.resource.wind_toolkit_data import HPCWindData

--- a/hopp/simulation/technologies/resource/nsrdb_data.py
+++ b/hopp/simulation/technologies/resource/nsrdb_data.py
@@ -15,13 +15,13 @@ NSRDB_NEW = "/datasets/NSRDB/current/nsrdb_"
 # To be called instead of SolarResource from hopp.simulation.technologies.resource
 class HPCSolarData(Resource):
     """
-    Class to manage Solar Resource data from NSRDB Datasets
+    Class to manage Solar Resource data from NSRDB Datasets.
 
     Attributes:
-        nsrdb_file (str): path of file that resource data is pulled from
-        site_gid (int): id for NSRDB location that resource data was pulled from
-        nsrdb_latitude (float): latitude of NSRDB location corresponding to site_gid
-        nsrdb_longitude: (float): longitude of NSRDB location corresponding to site_gid
+        nsrdb_file: (str) path of file that resource data is pulled from.
+        site_gid: (int) id for NSRDB location that resource data was pulled from.
+        nsrdb_latitude: (float) latitude of NSRDB location corresponding to site_gid.
+        nsrdb_longitude: (float) longitude of NSRDB location corresponding to site_gid.
         
     """
 

--- a/hopp/simulation/technologies/resource/nsrdb_data.py
+++ b/hopp/simulation/technologies/resource/nsrdb_data.py
@@ -1,0 +1,178 @@
+from rex import NSRDBX
+from rex.sam_resource import SAMResource
+import numpy as np 
+from hopp.simulation.technologies.resource.resource import Resource
+from typing import Optional, Union
+from pathlib import Path
+import os
+# import pandas as pd
+NSRDB_DEP = "/kfs2/datasets/NSRDB/deprecated_v3/nsrdb_"
+NSRDB_NEW = "/kfs2/datasets/NSRDB/current/nsrdb_"
+# Pull Solar Resource Data directly from NSRDB on HPC
+# To be called instead of SolarResource from hopp.simulation.technologies.resource
+class HPCSolarData(Resource):
+
+    def __init__(
+        self,
+        lat: float,
+        lon: float,
+        year: int,
+        nsrdb_source_path: Union[str,Path] = "",
+        filepath: str = "",
+        **kwargs):
+        """
+        Input:
+        lat (float): site latitude
+        lon (float): site longitude
+        resource_year (int): year to get resource data for
+        filepath (str): filepath for nsrdb data on HPC
+
+        Output: self.data
+            dictionary:
+                tz: float
+                elev: float
+                lat: float
+                lon: float
+                year: list of floats
+                month: list of floats
+                day: list of floats
+                hour: list of floats
+                minute: list of floats
+                dn: list of floats
+                df: list of floats
+                gh: list of floats
+                wspd: list of floats
+                tdry: list of floats
+                pres: list of floats
+                tdew: list of floats
+        """
+        # NOTE: self.data must be compatible with PVWatts.SolarResource.solar_resource_data to https://nrel-pysam.readthedocs.io/en/main/modules/Pvwattsv8.html#PySAM.Pvwattsv8.Pvwattsv8.SolarResource
+        self.latitude = lat
+        self.longitude = lon
+        self.year = year
+        super().__init__(lat, lon, year)
+
+        if filepath == "" and nsrdb_source_path=="":
+            self.nsrdb_file = NSRDB_NEW + "{}.h5".format(self.year)
+        elif filepath != "" and nsrdb_source_path == "":
+            self.nsrdb_file = filepath
+        elif filepath=="" and nsrdb_source_path !="":
+            self.nsrdb_file = os.path.join(str(nsrdb_source_path),"nsrdb_{}.h5".format(self.year))
+        else:
+            self.nsrdb_file = NSRDB_NEW + "{}.h5".format(self.year)
+        # Pull data from HPC NSRDB dataset
+        # self.extract_resource()
+        self.download_resource()
+
+        # Set solar resource data into SAM/PySAM digestible format
+        self.format_data()
+
+        # Define final dictionary
+        
+
+    # def extract_resource(self):
+    def download_resource(self):
+        # Define file to download from
+        # NOTE: HOPP is currently calling an old deprecated version of PSM v3.1 which corresponds to /api/nsrdb/v2/solar/psm3-download
+        
+
+        # NOTE: Current version of PSM v3.2.2 which corresponds to /api/nsrdb/v2/solar/psm3-2-2-download 
+       
+
+        # Open file with rex NSRDBX object
+        with NSRDBX(self.nsrdb_file, hsds=False) as f:
+            # get gid of location closest to given lat/lon coordinates
+            site_gid = f.lat_lon_gid((self.latitude,self.longitude))
+
+            # extract timezone, elevation, latitude and longitude from meta dataset with gid
+            self.time_zone = f.meta['timezone'].iloc[site_gid]
+            self.elevation = f.meta['elevation'].iloc[site_gid]
+            self.nsrdb_latitude = f.meta['latitude'].iloc[site_gid]
+            self.nsrdb_longitude = f.meta['longitude'].iloc[site_gid]
+            
+            # extract remaining datapoints: year, month, day, hour, minute, dn, df, gh, wspd,tdry, pres, tdew
+            # NOTE: datasets have readings at 0 and 30 minutes each hour, HOPP/SAM workflow requires only 30 minute reading values -> filter 0 minute readings with [1::2]
+            # NOTE: datasets are not auto shifted by timezone offset -> wrap extraction in SAMResource.roll_timeseries(input_array, timezone, #steps in an hour=1) to roll timezones
+            # NOTE: solar_resource.py code references solar_zenith_angle and RH = relative_humidity but I couldn't find them actually being utilized. Captured them below just in case.
+            self.year_arr = f.time_index.year.values[1::2]
+            self.month_arr = f.time_index.month.values[1::2]
+            self.day_arr = f.time_index.day.values[1::2]
+            self.hour_arr = f.time_index.hour.values[1::2]
+            self.minute_arr = f.time_index.minute.values[1::2]
+            self.dni_arr = SAMResource.roll_timeseries((f['dni', :, site_gid][1::2]), self.time_zone, 1)
+            self.dhi_arr = SAMResource.roll_timeseries((f['dhi', :, site_gid][1::2]), self.time_zone, 1)
+            self.ghi_arr = SAMResource.roll_timeseries((f['ghi', :, site_gid][1::2]), self.time_zone, 1)
+            self.wspd_arr = SAMResource.roll_timeseries((f['wind_speed', :, site_gid][1::2]), self.time_zone, 1)
+            self.tdry_arr = SAMResource.roll_timeseries((f['air_temperature', :, site_gid][1::2]), self.time_zone, 1)
+            # self.relative_humidity_arr = SAMResource.roll_timeseries((f['relative_humidity', :, site_gid][1::2]), self.time_zone, 1)
+            # self.solar_zenith_arr = SAMResource.roll_timeseries((f['solar_zenith_angle', :, site_gid][1::2]), self.time_zone, 1)
+            self.pres_arr = SAMResource.roll_timeseries((f['surface_pressure', :, site_gid][1::2]), self.time_zone, 1)
+            self.tdew_arr = SAMResource.roll_timeseries((f['dew_point', :, site_gid][1::2]), self.time_zone, 1)
+
+            self.site_gid = site_gid
+            
+
+    def format_data(self):
+        # Remove data from feb29 on leap years
+        if (self.year % 4) == 0:
+            feb29 = np.arange(1416,1440)
+            self.year_arr = np.delete(self.year_arr, feb29)
+            self.month_arr = np.delete(self.month_arr, feb29)
+            self.day_arr = np.delete(self.day_arr, feb29)
+            self.hour_arr = np.delete(self.hour_arr, feb29)
+            self.minute_arr = np.delete(self.minute_arr, feb29)
+            self.dni_arr = np.delete(self.dni_arr, feb29)
+            self.dhi_arr = np.delete(self.dhi_arr, feb29)
+            self.ghi_arr = np.delete(self.ghi_arr, feb29)
+            self.wspd_arr = np.delete(self.wspd_arr, feb29)
+            self.tdry_arr = np.delete(self.tdry_arr, feb29)
+            # self.relative_humidity_arr = np.delete(self.relative_humidity_arr, feb29)
+            # self.solar_zenith_arr = np.delete(self.solar_zenith_arr, feb29)
+            self.pres_arr = np.delete(self.pres_arr, feb29)
+            self.tdew_arr = np.delete(self.tdew_arr, feb29)
+
+        # round to desired precision and convert to desired data type
+        # NOTE: unsure if SAM/PySAM is sensitive to data types and decimal precision. If not sensitive, can remove .astype() and round() to increase computational efficiency
+        self.time_zone = float(self.time_zone)
+        self.elevation = round(float(self.elevation), 0)
+        self.nsrdb_latitude = round(float(self.nsrdb_latitude), 2)
+        self.nsrdb_longitude = round(float(self.nsrdb_longitude),2)
+        self.year_arr = list(self.year_arr.astype(float, copy=False))
+        self.month_arr = list(self.month_arr.astype(float, copy=False))
+        self.day_arr = list(self.day_arr.astype(float, copy=False))
+        self.hour_arr = list(self.hour_arr.astype(float, copy=False))
+        self.minute_arr = list(self.minute_arr.astype(float, copy=False))
+        self.dni_arr = list(self.dni_arr.astype(float, copy=False))
+        self.dhi_arr = list(self.dhi_arr.astype(float, copy=False))
+        self.ghi_arr = list(self.ghi_arr.astype(float, copy=False))
+        self.wspd_arr = list(self.wspd_arr.astype(float, copy=False))
+        self.tdry_arr = list(self.tdry_arr.astype(float, copy=False))
+        # self.relative_humidity_arr = list(np.round(self.relative_humidity_arr, decimals=1))
+        # self.solar_zenith_angle_arr = list(np.round(self.solar_zenith_angle_arr, decimals=1))
+        self.pres_arr = list(self.pres_arr.astype(float, copy=False))
+        self.tdew_arr = list(self.tdew_arr.astype(float, copy=False))
+        self.data = {} #unsure if this will cause problem
+    @Resource.data.setter
+    def data(self,data_dict):
+        dic = {
+            # 'site_gid': self.site_gid,
+            # 'nsrdb_lat':self.nsrdb_latitude,
+            # 'nsrdb_lon':self.nsrdb_longitude,
+            'tz' :     self.time_zone,
+            'elev' :   self.elevation,
+            'lat' :    self.nsrdb_latitude,
+            'lon' :    self.nsrdb_longitude,
+            'year' :   self.year_arr,
+            'month' :  self.month_arr,
+            'day' :    self.day_arr,
+            'hour' :   self.hour_arr,
+            'minute' : self.minute_arr,
+            'dn' :     self.dni_arr,
+            'df' :     self.dhi_arr,
+            'gh' :     self.ghi_arr,
+            'wspd' :   self.wspd_arr,
+            'tdry' :   self.tdry_arr,
+            'pres' :   self.pres_arr,
+            'tdew' :   self.tdew_arr
+            }
+        self._data = dic

--- a/hopp/simulation/technologies/resource/nsrdb_data.py
+++ b/hopp/simulation/technologies/resource/nsrdb_data.py
@@ -43,6 +43,9 @@ class HPCSolarData(Resource):
             nsrdb_source_path (Union[str,Path], optional): directory where NSRDB data is hosted on HPC. Defaults to "".
             filepath (str, optional): filepath to NSRDB h5 file on HPC. Defaults to "".
                 - should be formatted as: /path/to/file/name_of_file.h5
+        Raises:
+            ValueError: if year is not between 1998 and 2022 (inclusive)
+            FileNotFoundError: if nsrdb_file is not valid filepath
         """
        
         # NOTE: self.data must be compatible with PVWatts.SolarResource.solar_resource_data
@@ -63,6 +66,10 @@ class HPCSolarData(Resource):
         else:
             # use default filepaths
             self.nsrdb_file = NSRDB_NEW + "{}.h5".format(self.year)
+        
+        # Check for valid year
+        if self.year < 1998 or self.year > 2022:
+                raise ValueError(f"Resource year for NSRDB Data must be between 1998 and 2022 but {self.year} was provided")
         
         # Check for valid filepath for NSRDB file
         if not os.path.isfile(self.nsrdb_file):

--- a/hopp/simulation/technologies/resource/nsrdb_data.py
+++ b/hopp/simulation/technologies/resource/nsrdb_data.py
@@ -20,7 +20,7 @@ class HPCSolarData(Resource):
         lat (float): site latitude
         lon (float): site longitude
         year: year to get resource data for
-        nsrdb_source_path (str): directory where NSRDB data is hosted on HPC. Defaults to ""
+        nsrdb_source_path (str or Path): directory where NSRDB data is hosted on HPC. Defaults to ""
         filepath (str): filepath to NSRDB h5 file on HPC. Defaults to "".
             - should be formatted as: /path/to/file/name_of_file.h5
     """
@@ -34,26 +34,7 @@ class HPCSolarData(Resource):
         nsrdb_source_path: Union[str,Path] = "",
         filepath: str = "",
         ):
-        """
-        Output: self.data
-            dictionary:
-                tz: float
-                elev: float
-                lat: float
-                lon: float
-                year: list of floats
-                month: list of floats
-                day: list of floats
-                hour: list of floats
-                minute: list of floats
-                dn: list of floats
-                df: list of floats
-                gh: list of floats
-                wspd: list of floats
-                tdry: list of floats
-                pres: list of floats
-                tdew: list of floats
-        """
+       
         # NOTE: self.data must be compatible with PVWatts.SolarResource.solar_resource_data to https://nrel-pysam.readthedocs.io/en/main/modules/Pvwattsv8.html#PySAM.Pvwattsv8.Pvwattsv8.SolarResource
         self.latitude = lat
         self.longitude = lon
@@ -66,7 +47,7 @@ class HPCSolarData(Resource):
         elif filepath != "" and nsrdb_source_path == "":
             # filepath (full h5 filepath) is provided by user
             self.nsrdb_file = filepath
-        elif filepath=="" and nsrdb_source_path !="":
+        elif filepath == "" and nsrdb_source_path != "":
             # directory of h5 files (nsrdb_source_path) is provided by user
             self.nsrdb_file = os.path.join(str(nsrdb_source_path),"nsrdb_{}.h5".format(self.year))
         else:
@@ -162,6 +143,26 @@ class HPCSolarData(Resource):
     
     @Resource.data.setter
     def data(self,data_dict):
+        """
+        Output: self.data
+            dictionary:
+                tz (float): Time zone is for standard time in hours ahead of GMT
+                elev (float): Elevation is in meters above sea level
+                lat (float): degrees north of the equator
+                lon (float): degrees East of the prime meridian
+                year (list(int)): year
+                month (list(float)): number associated with month (1 = January)
+                day (list(float)): number indicating the day of month (Day = 1 is the first day of the month)
+                hour (list(float)): number indicating the hour of day (Hour = 0 is the first hour of the day)
+                minute (list(float)): number indicating minute of hour (Minute = 0 is the first minute of the hour)
+                dn (list(float)): Beam normal irradiance (W/m2)
+                df (list(float)): Diffuse horizontal irradiance (W/m2)
+                gh (list(float)): Global horizontal irradiance (W/m2)
+                wspd (list(float)): Wind speed at 10 meters above the ground (m/s)
+                tdry (list(float)): Ambient dry bulb temperature (°C)
+                pres (list(float)): Atmospheric pressure (millibar)
+                tdew (list(float)): Dew point temperature (°C)
+        """
         dic = {
             # 'site_gid': self.site_gid,
             # 'nsrdb_lat':self.nsrdb_latitude,

--- a/hopp/simulation/technologies/resource/nsrdb_data.py
+++ b/hopp/simulation/technologies/resource/nsrdb_data.py
@@ -54,18 +54,18 @@ class HPCSolarData(Resource):
 
         if filepath == "" and nsrdb_source_path=="":
             # use default filepath
-            self.nsrdb_file = NSRDB_NEW + "{}.h5".format(self.year)
+            self.nsrdb_file = NSRDB_NEW + f"{self.year}.h5"
         elif filepath != "" and nsrdb_source_path == "":
             # filepath (full h5 filepath) is provided by user
             if ".h5" not in filepath:
                 filepath = filepath + ".h5"
-            self.nsrdb_file = filepath
+            self.nsrdb_file = str(filepath)
         elif filepath == "" and nsrdb_source_path != "":
             # directory of h5 files (nsrdb_source_path) is provided by user
-            self.nsrdb_file = os.path.join(str(nsrdb_source_path),"nsrdb_{}.h5".format(self.year))
+            self.nsrdb_file = os.path.join(str(nsrdb_source_path),f"nsrdb_{self.year}.h5")
         else:
             # use default filepaths
-            self.nsrdb_file = NSRDB_NEW + "{}.h5".format(self.year)
+            self.nsrdb_file = NSRDB_NEW + f"{self.year}.h5"
         
         # Check for valid year
         if self.year < 1998 or self.year > 2022:

--- a/hopp/simulation/technologies/resource/nsrdb_data.py
+++ b/hopp/simulation/technologies/resource/nsrdb_data.py
@@ -98,10 +98,15 @@ class HPCSolarData(Resource):
             self.nsrdb_latitude = f.meta['latitude'].iloc[site_gid]
             self.nsrdb_longitude = f.meta['longitude'].iloc[site_gid]
             
-            # extract remaining datapoints: year, month, day, hour, minute, dn, df, gh, wspd,tdry, pres, tdew
-            # NOTE: datasets have readings at 0 and 30 minutes each hour, HOPP/SAM workflow requires only 30 minute reading values -> filter 0 minute readings with [1::2]
-            # NOTE: datasets are not auto shifted by timezone offset -> wrap extraction in SAMResource.roll_timeseries(input_array, timezone, #steps in an hour=1) to roll timezones
-            # NOTE: solar_resource.py code references solar_zenith_angle and RH = relative_humidity but I couldn't find them actually being utilized. Captured them below just in case.
+            # extract remaining datapoints: 
+            # year, month, day, hour, minute, dn, df, gh, wspd,tdry, pres, tdew
+
+            # 1) NOTE: datasets have readings at 0 and 30 minutes each hour, 
+            # HOPP/SAM workflow requires only 30 minute reading values -> filter 0 minute readings with [1::2]
+            # 2) NOTE: datasets are not auto shifted by timezone offset 
+            # -> wrap extraction in SAMResource.roll_timeseries(input_array, timezone, #steps in an hour=1) to roll timezones
+            # 3) NOTE: solar_resource.py code references solar_zenith_angle and RH = relative_humidity but I couldn't find them 
+            # actually being utilized. Captured them below just in case.
             self.year_arr = f.time_index.year.values[1::2]
             self.month_arr = f.time_index.month.values[1::2]
             self.day_arr = f.time_index.day.values[1::2]

--- a/hopp/simulation/technologies/resource/nsrdb_data.py
+++ b/hopp/simulation/technologies/resource/nsrdb_data.py
@@ -34,7 +34,7 @@ class HPCSolarData(Resource):
         nsrdb_source_path: Union[str,Path] = "",
         filepath: str = "",
         ):
-        """_summary_
+        """Class to pull solar resource data from NSRDB datasets hosted on the HPC
 
         Args:
             lat (float): latitude corresponding to location for solar resource data
@@ -54,6 +54,8 @@ class HPCSolarData(Resource):
             self.nsrdb_file = NSRDB_NEW + "{}.h5".format(self.year)
         elif filepath != "" and nsrdb_source_path == "":
             # filepath (full h5 filepath) is provided by user
+            if ".h5" not in filepath:
+                filepath = filepath + ".h5"
             self.nsrdb_file = filepath
         elif filepath == "" and nsrdb_source_path != "":
             # directory of h5 files (nsrdb_source_path) is provided by user

--- a/hopp/simulation/technologies/resource/wind_toolkit_data.py
+++ b/hopp/simulation/technologies/resource/wind_toolkit_data.py
@@ -1,0 +1,165 @@
+from rex import WindX
+from rex.sam_resource import SAMResource
+import numpy as np 
+from typing import Optional, Union
+from pathlib import Path
+import os
+from hopp.simulation.technologies.resource.resource import Resource
+WTK_V10_BASE = "/kfs2/datasets/WIND/conus/v1.0.0/wtk_conus_"
+WTK_V11_BASE = "/kfs2/datasets/WIND/conus/v1.1.0/wtk_conus_"
+class HPCWindData(Resource):
+    def __init__(
+        self,
+        lat: float,
+        lon: float,
+        year: int,
+        hub_height_meters: float,
+        wtk_source_path: Union[str,Path] = "",
+        filepath: str = "",
+        **kwargs
+        ):
+        """
+        Input:
+        lat (float): site latitude
+        lon (float): site longitude
+        resource_year (int): year to get resource data for
+        wtk_source_path (str): directory of wind resource data on HPC
+        filepath (str): filepath for wind toolkit h5 file on HPC
+        """
+        
+        
+        
+        self.latitude = lat
+        self.longitude = lon
+        self.year = year
+        super().__init__(lat, lon, year)
+
+        self.hub_height_meters = hub_height_meters
+        self.allowed_hub_heights_meters = [10, 40, 60, 80, 100, 120, 140, 160, 200]
+        self.data_hub_heights = self.calculate_heights_to_download()
+        
+
+        if filepath == "" and wtk_source_path=="":
+            if self.year < 2014:
+                self.wtk_file = WTK_V10_BASE + "{}.h5".format(self.year)
+            # wtk_file = '/datasets/WIND/conus/v1.0.0/wtk_conus_{year}.h5'.format(year=self.year)
+            elif self.year == 2014:
+                self.wtk_file = WTK_V11_BASE + "{}.h5".format(self.year)
+        elif filepath != "" and wtk_source_path == "":
+            self.wtk_file = filepath
+        elif filepath=="" and wtk_source_path !="":
+            self.wtk_file = os.path.join(str(wtk_source_path),"wtk_conus_{}.h5".format(self.year))
+        else:
+            if self.year < 2014:
+                self.wtk_file = WTK_V10_BASE + "{}.h5".format(self.year)
+            # wtk_file = '/datasets/WIND/conus/v1.0.0/wtk_conus_{year}.h5'.format(year=self.year)
+            elif self.year == 2014:
+                self.wtk_file = WTK_V11_BASE + "{}.h5".format(self.year)
+            
+        # self.extract_resource()
+        self.download_resource()
+        self.format_data() 
+
+        # self.data = {'heights': [float(h) for h in self.data_hub_heights for i in range(4)],
+        #              'fields':  [1, 2, 3, 4] * len(self.data_hub_heights),
+        #              'data':    self.combined_data
+        #             }
+
+
+    
+    def calculate_heights_to_download(self):
+        """
+        Given the system hub height, and the available hubheights from WindToolkit,
+        determine which heights to download to bracket the hub height
+        """
+        hub_height_meters = self.hub_height_meters
+
+        # evaluate hub height, determine what heights to download
+        heights = [hub_height_meters]
+        if hub_height_meters not in self.allowed_hub_heights_meters:
+            height_low = self.allowed_hub_heights_meters[0]
+            height_high = self.allowed_hub_heights_meters[-1]
+            for h in self.allowed_hub_heights_meters:
+                if h < hub_height_meters:
+                    height_low = h
+                elif h > hub_height_meters:
+                    height_high = h
+                    break
+            heights[0] = height_low
+            heights.append(height_high)
+
+        return heights
+    
+    # def extract_resource(self):
+    def download_resource(self):
+        # Define file to download from
+        # NOTE: Current setup of files on HPC WINDToolkit v1.0.0 = 2007-2013, v1.1.0 = 2014
+        
+
+        # Open file with rex WindX object
+        with WindX(self.wtk_file, hsds=False) as f:
+            # get gid of location closest to given lat/lon coordinates and timezone offset
+            site_gid = f.lat_lon_gid((self.latitude, self.longitude))
+            time_zone = f.meta['timezone'].iloc[site_gid]
+
+            # instantiate temp dictionary to hold each attributes dataset
+            self.wind_dict = {}
+            # loop through hub heights to download, capture datasets
+            # NOTE: datasets are not auto shifted by timezone offset -> wrap extraction in SAMResource.roll_timeseries(input_array, timezone, #steps in an hour=1) to roll timezones
+            # NOTE: pressure datasets unit = Pa, convert to atm via division by 101325
+            for h in self.data_hub_heights:
+                self.wind_dict['temperature_{height}m_arr'.format(height=h)] = SAMResource.roll_timeseries((f['temperature_{height}m'.format(height=h), :, site_gid]), time_zone, 1)
+                self.wind_dict['pressure_{height}m_arr'.format(height=h)] = SAMResource.roll_timeseries((f['pressure_{height}m'.format(height=h), :, site_gid]/101325), time_zone, 1)
+                self.wind_dict['windspeed_{height}m_arr'.format(height=h)] = SAMResource.roll_timeseries((f['windspeed_{height}m'.format(height=h), :, site_gid]), time_zone, 1)
+                self.wind_dict['winddirection_{height}m_arr'.format(height=h)] = SAMResource.roll_timeseries((f['winddirection_{height}m'.format(height=h), :, site_gid]), time_zone, 1)    
+
+            self.site_gid = site_gid
+    def format_data(self):
+        # Remove data from feb29 on leap years
+        if (self.year % 4) == 0:
+            feb29 = np.arange(1416,1440)
+            for key, value in self.wind_dict.items():
+                self.wind_dict[key] = np.delete(value, feb29)
+
+        # round to desired precision and concatenate data into format needed for data dictionary
+        if len(self.data_hub_heights) == 2:
+            # NOTE: Unsure if SAM/PySAM is sensitive to data types ie: floats with long precision vs to 2 or 3 decimals. If not sensitive, can remove following 8 lines of code to increase computational efficiency
+            self.wind_dict['temperature_{h}m_arr'.format(h=self.data_hub_heights[0])] = np.round((self.wind_dict['temperature_{h}m_arr'.format(h=self.data_hub_heights[0])]), decimals=1)
+            self.wind_dict['pressure_{h}m_arr'.format(h=self.data_hub_heights[0])] = np.round((self.wind_dict['pressure_{h}m_arr'.format(h=self.data_hub_heights[0])]), decimals=2)
+            self.wind_dict['windspeed_{h}m_arr'.format(h=self.data_hub_heights[0])] = np.round((self.wind_dict['windspeed_{h}m_arr'.format(h=self.data_hub_heights[0])]), decimals=3)
+            self.wind_dict['winddirection_{h}m_arr'.format(h=self.data_hub_heights[0])] = np.round((self.wind_dict['winddirection_{h}m_arr'.format(h=self.data_hub_heights[0])]), decimals=1)
+            self.wind_dict['temperature_{h}m_arr'.format(h=self.data_hub_heights[1])] = np.round((self.wind_dict['temperature_{h}m_arr'.format(h=self.data_hub_heights[1])]), decimals=1)
+            self.wind_dict['pressure_{h}m_arr'.format(h=self.data_hub_heights[1])] = np.round((self.wind_dict['pressure_{h}m_arr'.format(h=self.data_hub_heights[1])]), decimals=2)
+            self.wind_dict['windspeed_{h}m_arr'.format(h=self.data_hub_heights[1])] = np.round((self.wind_dict['windspeed_{h}m_arr'.format(h=self.data_hub_heights[1])]), decimals=3)
+            self.wind_dict['winddirection_{h}m_arr'.format(h=self.data_hub_heights[1])] = np.round((self.wind_dict['winddirection_{h}m_arr'.format(h=self.data_hub_heights[1])]), decimals=1)
+            # combine all data into one 2D list
+            self.combined_data = [list(a) for a in zip(self.wind_dict['temperature_{h}m_arr'.format(h=self.data_hub_heights[0])],
+                                                       self.wind_dict['pressure_{h}m_arr'.format(h=self.data_hub_heights[0])],
+                                                       self.wind_dict['windspeed_{h}m_arr'.format(h=self.data_hub_heights[0])],
+                                                       self.wind_dict['winddirection_{h}m_arr'.format(h=self.data_hub_heights[0])],
+                                                       self.wind_dict['temperature_{h}m_arr'.format(h=self.data_hub_heights[1])],
+                                                       self.wind_dict['pressure_{h}m_arr'.format(h=self.data_hub_heights[1])],
+                                                       self.wind_dict['windspeed_{h}m_arr'.format(h=self.data_hub_heights[1])],
+                                                       self.wind_dict['winddirection_{h}m_arr'.format(h=self.data_hub_heights[1])])]
+
+        elif len(self.data_hub_heights) == 1:
+            # NOTE: Unsure if SAM/PySAM is sensitive to data types ie: floats with long precision vs to 2 or 3 decimals. If not sensitive, can remove following 4 lines of code to increase computational efficiency
+            self.wind_dict['temperature_{h}m_arr'.format(h=self.data_hub_heights[0])] = np.round((self.wind_dict['temperature_{h}m_arr'.format(h=self.data_hub_heights[0])]), decimals=1)
+            self.wind_dict['pressure_{h}m_arr'.format(h=self.data_hub_heights[0])] = np.round((self.wind_dict['pressure_{h}m_arr'.format(h=self.data_hub_heights[0])]), decimals=2)
+            self.wind_dict['windspeed_{h}m_arr'.format(h=self.data_hub_heights[0])] = np.round((self.wind_dict['windspeed_{h}m_arr'.format(h=self.data_hub_heights[0])]), decimals=3)
+            self.wind_dict['winddirection_{h}m_arr'.format(h=self.data_hub_heights[0])] = np.round((self.wind_dict['winddirection_{h}m_arr'.format(h=self.data_hub_heights[0])]), decimals=1)
+            # combine all data into one 2D list
+            self.combined_data = [list(a) for a in zip(self.wind_dict['temperature_{h}m_arr'.format(h=self.data_hub_heights[0])],
+                                                       self.wind_dict['pressure_{h}m_arr'.format(h=self.data_hub_heights[0])],
+                                                       self.wind_dict['windspeed_{h}m_arr'.format(h=self.data_hub_heights[0])],
+                                                       self.wind_dict['winddirection_{h}m_arr'.format(h=self.data_hub_heights[0])])]
+        self.data = self.combined_data
+    
+    @Resource.data.setter
+    def data(self, data_file):
+        dic = {
+            'heights': [float(h) for h in self.data_hub_heights for i in range(4)],
+            'fields':  [1, 2, 3, 4] * len(self.data_hub_heights),
+            'data':    data_file #self.combined_data
+            }
+        self._data = dic

--- a/hopp/simulation/technologies/resource/wind_toolkit_data.py
+++ b/hopp/simulation/technologies/resource/wind_toolkit_data.py
@@ -31,7 +31,7 @@ class HPCWindData(Resource):
         wtk_source_path: Union[str,Path] = "",
         filepath: str = "",
         ):
-        """_summary_
+        """Class to pull wind resource data from WIND Toolkit datasets hosted on the HPC
 
         Args:
             lat (float): latitude corresponding to location for wind resource data
@@ -59,6 +59,8 @@ class HPCWindData(Resource):
                 self.wtk_file = WTK_V11_BASE + "{}.h5".format(self.year)
         elif filepath != "" and wtk_source_path == "":
             # filepath (full h5 filepath) is provided by user
+            if ".h5" not in filepath:
+                filepath = filepath + ".h5"
             self.wtk_file = filepath
         elif filepath == "" and wtk_source_path != "":
             # directory of h5 files (wtk_source_path) is provided by user

--- a/hopp/simulation/technologies/resource/wind_toolkit_data.py
+++ b/hopp/simulation/technologies/resource/wind_toolkit_data.py
@@ -42,6 +42,7 @@ class HPCWindData(Resource):
             filepath (str, optional): filepath to Wind Toolkit h5 file on HPC. Defaults to "".
                 - should be formatted as: /path/to/file/name_of_file.h5
         Raises:
+            ValueError: if year is not between 2007 and 2014 (inclusive)
             FileNotFoundError: if wtk_file is not valid filepath
         """
         super().__init__(lat, lon, year)
@@ -50,10 +51,13 @@ class HPCWindData(Resource):
         self.allowed_hub_heights_meters = [10, 40, 60, 80, 100, 120, 140, 160, 200]
         self.data_hub_heights = self.calculate_heights_to_download()
         
-
+        # Check for valid year
+        if self.year < 2007 or self.year > 2014:
+            raise ValueError(f"Resource year for WIND Toolkit Data must be between 2007 and 2014 but {self.year} was provided")
+        
         if filepath == "" and wtk_source_path=="":
             # use default filepaths based on resource year
-            if self.year < 2014:
+            if self.year < 2014 and self.year>=2007:
                 self.wtk_file = WTK_V10_BASE + "{}.h5".format(self.year)
             elif self.year == 2014:
                 self.wtk_file = WTK_V11_BASE + "{}.h5".format(self.year)

--- a/hopp/simulation/technologies/resource/wind_toolkit_data.py
+++ b/hopp/simulation/technologies/resource/wind_toolkit_data.py
@@ -125,7 +125,8 @@ class HPCWindData(Resource):
             # instantiate temp dictionary to hold each attributes dataset
             self.wind_dict = {}
             # loop through hub heights to download, capture datasets
-            # NOTE: datasets are not auto shifted by timezone offset -> wrap extraction in SAMResource.roll_timeseries(input_array, timezone, #steps in an hour=1) to roll timezones
+            # NOTE: datasets are not auto shifted by timezone offset 
+            # -> wrap extraction in SAMResource.roll_timeseries(input_array, timezone, #steps in an hour=1) to roll timezones
             # NOTE: pressure datasets unit = Pa, convert to atm via division by 101325
             for h in self.data_hub_heights:
                 self.wind_dict['temperature_{height}m_arr'.format(height=h)] = SAMResource.roll_timeseries((f['temperature_{height}m'.format(height=h), :, site_gid]), time_zone, 1)
@@ -164,7 +165,8 @@ class HPCWindData(Resource):
                                                        self.wind_dict['winddirection_{h}m_arr'.format(h=self.data_hub_heights[1])])]
 
         elif len(self.data_hub_heights) == 1:
-            # NOTE: Unsure if SAM/PySAM is sensitive to data types ie: floats with long precision vs to 2 or 3 decimals. If not sensitive, can remove following 4 lines of code to increase computational efficiency
+            # NOTE: Unsure if SAM/PySAM is sensitive to data types ie: floats with long precision vs to 2 or 3 decimals. 
+            # If not sensitive, can remove following 4 lines of code to increase computational efficiency
             self.wind_dict['temperature_{h}m_arr'.format(h=self.data_hub_heights[0])] = np.round((self.wind_dict['temperature_{h}m_arr'.format(h=self.data_hub_heights[0])]), decimals=1)
             self.wind_dict['pressure_{h}m_arr'.format(h=self.data_hub_heights[0])] = np.round((self.wind_dict['pressure_{h}m_arr'.format(h=self.data_hub_heights[0])]), decimals=2)
             self.wind_dict['windspeed_{h}m_arr'.format(h=self.data_hub_heights[0])] = np.round((self.wind_dict['windspeed_{h}m_arr'.format(h=self.data_hub_heights[0])]), decimals=3)

--- a/hopp/simulation/technologies/resource/wind_toolkit_data.py
+++ b/hopp/simulation/technologies/resource/wind_toolkit_data.py
@@ -58,23 +58,23 @@ class HPCWindData(Resource):
         if filepath == "" and wtk_source_path=="":
             # use default filepaths based on resource year
             if self.year < 2014 and self.year>=2007:
-                self.wtk_file = WTK_V10_BASE + "{}.h5".format(self.year)
+                self.wtk_file = WTK_V10_BASE + f"{self.year}.h5"
             elif self.year == 2014:
-                self.wtk_file = WTK_V11_BASE + "{}.h5".format(self.year)
+                self.wtk_file = WTK_V11_BASE + f"{self.year}.h5"
         elif filepath != "" and wtk_source_path == "":
             # filepath (full h5 filepath) is provided by user
             if ".h5" not in filepath:
                 filepath = filepath + ".h5"
-            self.wtk_file = filepath
+            self.wtk_file = str(filepath)
         elif filepath == "" and wtk_source_path != "":
             # directory of h5 files (wtk_source_path) is provided by user
-            self.wtk_file = os.path.join(str(wtk_source_path),"wtk_conus_{}.h5".format(self.year))
+            self.wtk_file = os.path.join(str(wtk_source_path),f"wtk_conus_{self.year}.h5")
         else:
             # use default filepaths
-            if self.year < 2014:
-                self.wtk_file = WTK_V10_BASE + "{}.h5".format(self.year)
+            if self.year < 2014 and self.year>=2007:
+                self.wtk_file = WTK_V10_BASE + f"{self.year}.h5"
             elif self.year == 2014:
-                self.wtk_file = WTK_V11_BASE + "{}.h5".format(self.year)
+                self.wtk_file = WTK_V11_BASE + f"{self.year}.h5"
         
         # Check for valid filepath for Wind Toolkit file
         if not os.path.isfile(self.wtk_file):

--- a/hopp/simulation/technologies/resource/wind_toolkit_data.py
+++ b/hopp/simulation/technologies/resource/wind_toolkit_data.py
@@ -15,10 +15,10 @@ class HPCWindData(Resource):
     Class to manage Wind Resource data from Wind Toolkit Datasets
     
     Attributes:
-        wtk_file (str): path of file that resource data is pulled from
-        site_gid (int): id for Wind Toolkit location that resource data was pulled from
-        wtk_latitude (float): latitude of Wind Toolkit location corresponding to site_gid
-        wtk_longitude: (float): longitude of Wind Toolkit location corresponding to site_gid
+        wtk_file: (str) path of file that resource data is pulled from
+        site_gid: (int) id for Wind Toolkit location that resource data was pulled from
+        wtk_latitude: (float) latitude of Wind Toolkit location corresponding to site_gid
+        wtk_longitude: (float) longitude of Wind Toolkit location corresponding to site_gid
     """
 
 

--- a/hopp/simulation/technologies/resource/wind_toolkit_data.py
+++ b/hopp/simulation/technologies/resource/wind_toolkit_data.py
@@ -21,6 +21,8 @@ class HPCWindData(Resource):
         filepath (str): filepath for wind toolkit h5 file on HPC. Defaults to ""
             - should be formatted as: /path/to/file/name_of_file.h5
     """
+
+
     def __init__(
         self,
         lat: float,
@@ -50,7 +52,7 @@ class HPCWindData(Resource):
         elif filepath != "" and wtk_source_path == "":
             # filepath (full h5 filepath) is provided by user
             self.wtk_file = filepath
-        elif filepath=="" and wtk_source_path !="":
+        elif filepath == "" and wtk_source_path != "":
             # directory of h5 files (wtk_source_path) is provided by user
             self.wtk_file = os.path.join(str(wtk_source_path),"wtk_conus_{}.h5".format(self.year))
         else:
@@ -158,6 +160,20 @@ class HPCWindData(Resource):
     
     @Resource.data.setter
     def data(self, data_file):
+        """Wind resource data formatted for SAM
+
+        Output: self.data
+            dictionary:
+                heights: list(int): floats corresponding to hub-height for 'data' entry
+                fields list(int): integers corresponding to data type for 'data' entry
+                data:
+                    temperature: Ambient temperature in degrees Celsius
+                    pressure: Atmospheric pressure in in atmospheres.
+                    windspeed: Wind speed in meters per second (m/s)
+                    winddirection: Wind direction in degrees east of north (degrees).
+                        Zero degrees indicates wind from the north, and 90 degrees indicates wind from the east.
+
+        """
         dic = {
             'heights': [float(h) for h in self.data_hub_heights for i in range(4)],
             'fields':  [1, 2, 3, 4] * len(self.data_hub_heights),

--- a/hopp/simulation/technologies/sites/site_info.py
+++ b/hopp/simulation/technologies/sites/site_info.py
@@ -52,6 +52,14 @@ class SiteInfo(BaseClass):
         solar_resource_file: Path to solar resource file. Defaults to "".
         wind_resource_file: Path to wind resource file. Defaults to "".
         grid_resource_file: Path to grid pricing data file. Defaults to "".
+        path_resource: Path to folder to save resource files. 
+            Defaults to ROOT/simulation/resource_files
+        wtk_source_path (Optional): directory of Wind Toolkit h5 files hosted on HPC.
+            Only used if renewable_resource_origin != "API"
+        nsrdb_source_path (Optional): directory of NSRDB h5 files hosted on HPC.
+            Only used if renewable_resource_origin != "API"
+        renewable_resource_origin (str): whether to download resource data from API or load directly from datasets files.
+            Options are "API" or "HPC". Defaults to "API"
         hub_height: Turbine hub height for resource download in meters. Defaults to 97.0.
         capacity_hours: Boolean list indicating hours for capacity payments. Defaults to [].
         desired_schedule: Absolute desired load profile in MWe. Defaults to [].
@@ -122,7 +130,8 @@ class SiteInfo(BaseClass):
             urdb_label (str): Link to `Utility Rate DataBase <https://openei.org/wiki/Utility_Rate_Database>`_ label for REopt runs.
             follow_desired_schedule (bool): Indicates if a desired schedule was provided. Defaults to False.
         """
-        set_nrel_key_dot_env()
+        if self.renewable_resource_origin=="API":
+            set_nrel_key_dot_env()
 
         data = self.data
         if 'site_boundaries' in data:
@@ -139,7 +148,10 @@ class SiteInfo(BaseClass):
         self.lon = data['lon']
 
         if 'year' not in data:
-            data['year'] = 2012
+            data['year'] = self.year
+        
+        self.year = data["year"]
+
         if 'tz' in data:
             self.tz = data['tz']
         

--- a/hopp/simulation/technologies/sites/site_info.py
+++ b/hopp/simulation/technologies/sites/site_info.py
@@ -173,7 +173,7 @@ class SiteInfo(BaseClass):
                     self.wind_resource = WindResource(data['lat'], data['lon'], data['year'], wind_turbine_hub_ht=self.hub_height,
                                                 path_resource=self.path_resource, filepath=self.wind_resource_file, source=self.wind_resource_origin)
                 else:
-                    self.wind_resource = HPCWindData(data['lat'], data['lon'], data['year'], hub_height_meters=self.hub_height,
+                    self.wind_resource = HPCWindData(data['lat'], data['lon'], data['year'], wind_turbine_hub_ht=self.hub_height,
                                                     wtk_source_path=self.wtk_source_path, filepath=self.wind_resource_file)
             n_timesteps = len(self.wind_resource.data['data']) // 8760 * 8760
             if self.n_timesteps is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ dependencies = [
     "attrs",
     "utm",
     "pyyaml-include",
-    "profast"
+    "profast",
+    "NREL-rex"
 ]
 keywords = [
     "python3",

--- a/tests/hopp/test_resource_download.py
+++ b/tests/hopp/test_resource_download.py
@@ -5,11 +5,13 @@ import os
 from hopp import ROOT_DIR
 from hopp.simulation.technologies.resource.solar_resource import BASE_URL as SOLAR_URL
 from hopp.simulation.technologies.resource.wind_resource import WTK_BASE_URL, TAP_BASE_URL
-from hopp.simulation.technologies.resource import SolarResource, WindResource, Resource
+from hopp.simulation.technologies.resource import SolarResource, WindResource, Resource, HPCWindData, HPCSolarData
 from hopp.utilities.utils_for_tests import DEFAULT_WIND_RESOURCE_FILE
 
 import PySAM.Windpower as wp
 import PySAM.Pvwattsv8 as pv
+
+import pytest
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -154,3 +156,19 @@ def test_from_file():
         filepath=str(solar_file)
     )
     assert(len(solar_resource.data['gh']) > 0)
+
+def test_wtk_resource_filenotfound():
+    wtk_fake_dir = str(ROOT_DIR)
+    resource_year = 2012
+    wtk_fake_fpath = os.path.join(str(ROOT_DIR),f"wtk_conus_{resource_year}.h5")
+    with pytest.raises(FileNotFoundError) as err:
+        HPCWindData(lat = 35.201, lon = -101.945, year = resource_year, wind_turbine_hub_ht = 110, wtk_source_path=wtk_fake_dir)
+    assert str(err.value) == f"Cannot find Wind Toolkit .h5 file, filepath {wtk_fake_fpath} does not exist"
+
+def test_nsrdb_resource_filenotfound():
+    nsrdb_fake_dir = str(ROOT_DIR)
+    resource_year = 2012
+    nsrdb_fake_fpath = os.path.join(str(ROOT_DIR),f"nsrdb_{resource_year}.h5")
+    with pytest.raises(FileNotFoundError) as err:
+        HPCSolarData(lat = 35.201, lon = -101.945, year = 2012, nsrdb_source_path=nsrdb_fake_dir)
+    assert str(err.value) == f"Cannot find NSRDB .h5 file, filepath {nsrdb_fake_fpath} does not exist"

--- a/tests/hopp/test_resource_download.py
+++ b/tests/hopp/test_resource_download.py
@@ -157,7 +157,7 @@ def test_from_file():
     )
     assert(len(solar_resource.data['gh']) > 0)
 
-def test_wtk_resource_filenotfound():
+def test_wtk_resource_filenotfound_wtk_source_path():
     wtk_fake_dir = str(ROOT_DIR)
     resource_year = 2012
     wtk_fake_fpath = os.path.join(str(ROOT_DIR),f"wtk_conus_{resource_year}.h5")
@@ -165,15 +165,21 @@ def test_wtk_resource_filenotfound():
         HPCWindData(lat = 35.201, lon = -101.945, year = resource_year, wind_turbine_hub_ht = 110, wtk_source_path=wtk_fake_dir)
     assert str(err.value) == f"Cannot find Wind Toolkit .h5 file, filepath {wtk_fake_fpath} does not exist"
 
+def test_wtk_resource_filenotfound_filepath():
+    resource_year = 2012
+    wtk_fake_fpath = os.path.join(str(ROOT_DIR),f"wtk_conus_{resource_year}.h5")
+    with pytest.raises(FileNotFoundError) as err:
+        HPCWindData(lat = 35.201, lon = -101.945, year = resource_year, wind_turbine_hub_ht = 110, filepath = wtk_fake_fpath)
+    assert str(err.value) == f"Cannot find Wind Toolkit .h5 file, filepath {wtk_fake_fpath} does not exist"
+
 def test_wtk_resource_invalid_year():
     wtk_fake_dir = str(ROOT_DIR)
     resource_year = 2006
-    wtk_fake_fpath = os.path.join(str(ROOT_DIR),f"wtk_conus_{resource_year}.h5")
     with pytest.raises(ValueError) as err:
         HPCWindData(lat = 35.201, lon = -101.945, year = resource_year, wind_turbine_hub_ht = 110, wtk_source_path=wtk_fake_dir)
     assert str(err.value) == f"Resource year for WIND Toolkit Data must be between 2007 and 2014 but {resource_year} was provided"
 
-def test_nsrdb_resource_filenotfound():
+def test_nsrdb_resource_filenotfound_nsrdb_source_path():
     nsrdb_fake_dir = str(ROOT_DIR)
     resource_year = 2012
     nsrdb_fake_fpath = os.path.join(str(ROOT_DIR),f"nsrdb_{resource_year}.h5")
@@ -181,10 +187,16 @@ def test_nsrdb_resource_filenotfound():
         HPCSolarData(lat = 35.201, lon = -101.945, year = resource_year, nsrdb_source_path=nsrdb_fake_dir)
     assert str(err.value) == f"Cannot find NSRDB .h5 file, filepath {nsrdb_fake_fpath} does not exist"
 
+def test_nsrdb_resource_filenotfound_filepath():
+    resource_year = 2012
+    nsrdb_fake_fpath = os.path.join(str(ROOT_DIR),f"nsrdb_{resource_year}.h5")
+    with pytest.raises(FileNotFoundError) as err:
+        HPCSolarData(lat = 35.201, lon = -101.945, year = resource_year, filepath = nsrdb_fake_fpath)
+    assert str(err.value) == f"Cannot find NSRDB .h5 file, filepath {nsrdb_fake_fpath} does not exist"
+
 def test_nsrdb_resource_invalid_year():
     nsrdb_fake_dir = str(ROOT_DIR)
     resource_year = 2023
-    nsrdb_fake_fpath = os.path.join(str(ROOT_DIR),f"nsrdb_{resource_year}.h5")
     with pytest.raises(ValueError) as err:
         HPCSolarData(lat = 35.201, lon = -101.945, year = resource_year, nsrdb_source_path=nsrdb_fake_dir)
     assert str(err.value) == f"Resource year for NSRDB Data must be between 1998 and 2022 but {resource_year} was provided"

--- a/tests/hopp/test_resource_download.py
+++ b/tests/hopp/test_resource_download.py
@@ -165,10 +165,26 @@ def test_wtk_resource_filenotfound():
         HPCWindData(lat = 35.201, lon = -101.945, year = resource_year, wind_turbine_hub_ht = 110, wtk_source_path=wtk_fake_dir)
     assert str(err.value) == f"Cannot find Wind Toolkit .h5 file, filepath {wtk_fake_fpath} does not exist"
 
+def test_wtk_resource_invalid_year():
+    wtk_fake_dir = str(ROOT_DIR)
+    resource_year = 2006
+    wtk_fake_fpath = os.path.join(str(ROOT_DIR),f"wtk_conus_{resource_year}.h5")
+    with pytest.raises(ValueError) as err:
+        HPCWindData(lat = 35.201, lon = -101.945, year = resource_year, wind_turbine_hub_ht = 110, wtk_source_path=wtk_fake_dir)
+    assert str(err.value) == f"Resource year for WIND Toolkit Data must be between 2007 and 2014 but {resource_year} was provided"
+
 def test_nsrdb_resource_filenotfound():
     nsrdb_fake_dir = str(ROOT_DIR)
     resource_year = 2012
     nsrdb_fake_fpath = os.path.join(str(ROOT_DIR),f"nsrdb_{resource_year}.h5")
     with pytest.raises(FileNotFoundError) as err:
-        HPCSolarData(lat = 35.201, lon = -101.945, year = 2012, nsrdb_source_path=nsrdb_fake_dir)
+        HPCSolarData(lat = 35.201, lon = -101.945, year = resource_year, nsrdb_source_path=nsrdb_fake_dir)
     assert str(err.value) == f"Cannot find NSRDB .h5 file, filepath {nsrdb_fake_fpath} does not exist"
+
+def test_nsrdb_resource_invalid_year():
+    nsrdb_fake_dir = str(ROOT_DIR)
+    resource_year = 2023
+    nsrdb_fake_fpath = os.path.join(str(ROOT_DIR),f"nsrdb_{resource_year}.h5")
+    with pytest.raises(ValueError) as err:
+        HPCSolarData(lat = 35.201, lon = -101.945, year = resource_year, nsrdb_source_path=nsrdb_fake_dir)
+    assert str(err.value) == f"Resource year for NSRDB Data must be between 1998 and 2022 but {resource_year} was provided"


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Load wind and solar resource data from h5 datasets

<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
Added the option and functionality to load wind and solar resource data from Wind Toolkit and NSRDB data files (usually hosted on HPC but can be downloaded locally too). This new feature is primarily based on work previously done by @dakotaramos. To use this functionality, the user must input `renewable_resource_origin = HPC` when creating the `SiteInfo` object. Did not add new tests because this can only be used if the h5 type datafile are downloaded locally or code is run on an HPC that hosts these datasets. 

Also fixed bug in `SiteInfo` when setting `year` from input argument rather than from the input `data` dictionary.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `RELEASE.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [-] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->


## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `hopp/simulation/technologies/resource/wind_toolkit_data.py`
  - `HPCWindData`: new `Resource` type class to load wind resource data from Wind Toolkit data files hosted on HPC
- `hopp/simulation/technologies/resource/nsrdb_data.py`
  - `HPCSolarData`: new `Resource` type class to load solar resource data from NSRDB data files hosted on HPC
- `hopp/simulation/technologies/resource/__init__.py`
  - added imports for `HPCSolarData` and `HPCWindData`
- `hopp/simulation/sites/site_info.py`
  - added `renewable_resource_origin` attribute to specify whether to download resource data from API call or load from HPC datasets
  - changed `solar_resource` and `wind_resource` to optional inputs to prevent redundant resource file loading
  - added `wtk_source_path` and `nsrdb_source_path` as optional inputs to specify WTK or NSRDB data set directories
  - fixed bug that sets resource year to 2012 if 'year' isn't in 'data' dictionary but input to `SiteInfo` as argument
- `pyproject.toml`
  - added NREL-rex to dependencies list
## Additional supporting information

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in hopp/__init__.py
- [x] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/HOPP repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
