### PR TITLE
minor clean-ups to floris.py

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@
 version: 2
 sphinx:
   # Path to your Sphinx configuration file.
-  configuration: docs/_conf.py
+  configuration: docs/conf.py
 
 # Set the version of Python and other tools you might need
 build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,9 @@
 
 # Required
 version: 2
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/_config.py
 
 # Set the version of Python and other tools you might need
 build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@
 version: 2
 sphinx:
   # Path to your Sphinx configuration file.
-  configuration: docs/_config.py
+  configuration: docs/_conf.py
 
 # Set the version of Python and other tools you might need
 build:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## Unreleased, TBD
++ minor clean up to floris.py - removed unnecessary data exportation and fixed bug in value()
+
 ## Version 3.1.1, Dec. 18, 2024
 
 * Enhanced PV plant functionality: added tilting solar panel support, improved system design handling, and refined tilt angle calculations.

--- a/hopp/simulation/technologies/wind/floris.py
+++ b/hopp/simulation/technologies/wind/floris.py
@@ -132,14 +132,15 @@ class Floris(BaseClass):
         power_turbines[:, self.start_idx:self.end_idx] = self.fi.get_turbine_powers().reshape((self.nTurbs, self.end_idx - self.start_idx))
         power_farm[self.start_idx:self.end_idx] = self.fi.get_farm_power().reshape((self.end_idx - self.start_idx))
 
+        operational_efficiency = ((100 - self._operational_losses)/100)
         # Adding losses from PySAM defaults (excluding turbine and wake losses)
-        self.gen = power_farm * ((100 - self._operational_losses)/100) / 1000 # kW
+        self.gen = power_farm * operational_efficiency / 1000 # kW
 
         self.annual_energy = np.sum(self.gen) # kWh
         self.capacity_factor = np.sum(self.gen) / (8760 * self.system_capacity) * 100
-        self.turb_powers = power_turbines * (100 - self._operational_losses) / 100 / 1000 # kW
+        self.turb_powers = power_turbines * operational_efficiency / 1000 # kW
         self.turb_velocities = self.fi.turbine_average_velocities
-        self.annual_energy_pre_curtailment_ac = self.annual_energy
+        self.annual_energy_pre_curtailment_ac = np.sum(self.gen) # kWh
 
     def export(self):
         """

--- a/hopp/simulation/technologies/wind/floris.py
+++ b/hopp/simulation/technologies/wind/floris.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 class Floris(BaseClass):
     site: SiteInfo = field()
     config: "WindConfig" = field()
+    verbose: bool = field(default = True)
 
     _operational_losses: float = field(init=False)
     _timestep: Tuple[int, int] = field(init=False)
@@ -43,14 +44,6 @@ class Floris(BaseClass):
 
         self.wind_resource_data = self.site.wind_resource.data
         self.speeds, self.wind_dirs = self.parse_resource_data()
-
-        save_data = np.zeros((len(self.speeds),2))
-        save_data[:,0] = self.speeds
-        save_data[:,1] = self.wind_dirs
-
-        with open('speed_dir_data.csv', 'w', newline='') as fo:
-            writer = csv.writer(fo)
-            writer.writerows(save_data)
 
         self.wind_farm_xCoordinates = self.fi.layout_x
         self.wind_farm_yCoordinates = self.fi.layout_y
@@ -90,7 +83,7 @@ class Floris(BaseClass):
         """
         if set_value = None, then retrieve value; otherwise overwrite variable's value
         """
-        if set_value:
+        if set_value is not None:
             self.__setattr__(name, set_value)
         else:
             return self.__getattribute__(name)
@@ -119,8 +112,9 @@ class Floris(BaseClass):
         return speeds, wind_dirs
 
     def execute(self, project_life):
-
-        print('Simulating wind farm output in FLORIS...')
+        
+        if self.verbose:
+            print('Simulating wind farm output in FLORIS...')
 
         # find generation of wind farm
         power_turbines = np.zeros((self.nTurbs, 8760))


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Floris wrapper clean-up

<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
Previously when using floris to simulate the wind farm, it would write the wind resource data to speed_dir_data.csv. This file is never read or used anywhere else in the code - so this has been removed. All other relevant information for this PR is found in the below section.


Note: this also includes a patch fix for building readthedocs (see more information [here](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/))

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `RELEASE.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [-] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->


## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `hopp/simulation/technologies/wind/floris.py`
  - `value()`: fixed the `set_value` functionality to work as documented
  - `execute()`: cleaned up how operational losses are applied and to only print 'Simulating wind farm output in FLORIS...' if `verbose` is True (`verbose` is a new attribute which defaults to True)
  - `parse_resource_data`: removed part that exports wind resource data to speed_dir_data.csv (this was unused and does not impact the functionality at all)

## Additional supporting information

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in hopp/__init__.py
- [x] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/HOPP repository and push
- [x] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
