### PR TITLE
Wave Resource Deprecated Methods

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,8 @@
 * Added option and functionality to load wind and solar resource data from NSRDB and Wind Toolkit data files if user-specified.
 * Fixed a bug in site_info that set resource year to 2012 even if otherwise specified.
 + minor clean up to floris.py - removed unnecessary data exportation and fixed bug in value()
-+ bug fix in load following heuristic method: only using beginning of variable load signals 
++ bug fix in load following heuristic method: only using beginning of variable load signals
+* Update deprecated methods in wave_resource.py 
 
 ## Version 3.1.1, Dec. 18, 2024
 

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -21,6 +21,7 @@ parts:
       - file: api/resource/wind_api
       - file: api/resource/solar_hpc
       - file: api/resource/wind_hpc
+      - file: api/resource/wave_data
   - file: api/hybrid_simulation
   - file: api/technology/index
     sections:

--- a/docs/api/resource/index.md
+++ b/docs/api/resource/index.md
@@ -6,6 +6,7 @@ These are the primary methods for accessing wind and solar resource data.
 - [Wind Resource (API)](resource:wind-resource)
 - [Solar Resource (NSRDB Dataset on NREL HPC)](resource:nsrdb-data)
 - [Wind Resource (Wind Toolkit Dataset on NREL HPC)](resource:wtk-data)
+- [Wave Resource (Data)](resource:wave-resource)
 
 ## NREL API Keys
 

--- a/docs/api/resource/wave_data.md
+++ b/docs/api/resource/wave_data.md
@@ -1,0 +1,11 @@
+(resource:wave-resource)=
+# Wave Resource
+
+**NOTE: Downloading wave resource data is not yet enabled** but can still be loaded from existing data files.
+
+```{eval-rst}
+.. autoclass:: hopp.simulation.technologies.resource.wave_resource.WaveResource
+    :members:
+    :undoc-members:
+    :exclude-members: _abc_impl, check_download_dir, call_api
+```

--- a/hopp/simulation/technologies/resource/wave_resource.py
+++ b/hopp/simulation/technologies/resource/wave_resource.py
@@ -107,10 +107,10 @@ class WaveResource(Resource):
                 last_hour = data_df.index.max()
                 missing_hours = 8760 - len(data_df['energy_period'])
 
-                missing_time = pd.date_range(last_hour + pd.Timedelta(hours=1),periods=missing_hours, freq='H')
+                missing_time = pd.date_range(last_hour + pd.Timedelta(hours=1),periods=missing_hours, freq='h')
                 missing_rows = pd.DataFrame(index=missing_time, columns=df.columns)
                 data_df = pd.concat([data_df, missing_rows]).sort_index()
-                data_df = data_df.fillna(method='ffill') # forward fill
+                data_df = data_df.ffill() # forward fill
 
             data_df = data_df.reset_index()
             dic = dict()

--- a/hopp/simulation/technologies/resource/wave_resource.py
+++ b/hopp/simulation/technologies/resource/wave_resource.py
@@ -99,7 +99,7 @@ class WaveResource(Resource):
             df['energy_period'] = wavefile_model.Outputs.energy_period
 
             # Resample data and linearly interpolate to hourly data
-            data_df = df.resample("H").mean()
+            data_df = df.resample("h").mean()
             data_df = data_df.interpolate(method='linear')
 
             # If data cannot interpolate last hours

--- a/hopp/simulation/technologies/resource/wave_resource.py
+++ b/hopp/simulation/technologies/resource/wave_resource.py
@@ -37,10 +37,10 @@ class WaveResource(Resource):
             The wave resource data should be in the format:
                 - Rows 1 and 2: Header rows with location info.
                 - Row 3: Column headings for time-series data 
-                (`Year`, `Month`, `Day`, `Hour`, `Minute`, `wave height`, `wave period`).
+                    - (`Year`, `Month`, `Day`, `Hour`, `Minute`, `wave height`, `wave period`).
                 - Rows 4+: Data values:
-                - `wave height` (significant wave height) in meters.
-                - `wave period` (energy period) in seconds.
+                    - `wave height` (significant wave height) in meters.
+                    - `wave period` (energy period) in seconds.
 
             Example file: 
             `hopp/simulation/resource_files/wave/Wave_resource_timeseries.csv`

--- a/hopp/simulation/technologies/resource/wave_resource.py
+++ b/hopp/simulation/technologies/resource/wave_resource.py
@@ -7,7 +7,11 @@ from hopp.simulation.technologies.resource.resource import *
 
 class WaveResource(Resource):
     """
-    Class to manage Wave Resource data
+    Class to manage Wave Resource data.
+
+    This class loads, processes, and formats wave energy resource data, 
+    either from a file or a provided dataset, for compatibility with 
+    PySAM's wave energy models.
     """
     def __init__(
         self, 
@@ -19,20 +23,27 @@ class WaveResource(Resource):
         **kwargs
     ):
         """
-        lat (float): latitude
-        lon (float): longitude
-        year (int): year
-        path_resource (str): directory where to save downloaded files
-        filepath (str): file path of resource file to load
+        Initializes the WaveResource object.
 
-        see 'hopp/simulation/resource_files/wave/Wave_resource_timeseries.csv' for example wave resource file
-        file format for time series for wave energy resource data
-            rows 1 and 2: header rows containing info about location
-            row 3: headings for time series wave data 
-                (month, day, hour, minute, wave height, wave period)
-            row 4 and higher: contains data itself
-                (significant) wave height in meters
-                wave (energy) period in seconds
+        Args:
+            lat (float): Latitude of the resource location.
+            lon (float): Longitude of the resource location.
+            year (int): Year of the resource data.
+            path_resource (str, optional): Directory where downloaded files are saved. Defaults to "".
+            filepath (str, optional): File path of the resource file to load. Defaults to "".
+            **kwargs: Additional keyword arguments.
+
+        Notes:
+            The wave resource data should be in the format:
+            - Rows 1 and 2: Header rows with location info.
+            - Row 3: Column headings for time-series data 
+              (`month`, `day`, `hour`, `minute`, `wave height`, `wave period`).
+            - Rows 4+: Data values:
+              - `wave height` (significant wave height) in meters.
+              - `wave period` (energy period) in seconds.
+
+            Example file: 
+            `hopp/simulation/resource_files/wave/Wave_resource_timeseries.csv`
         """
         super().__init__(lat, lon, year)
 
@@ -50,13 +61,24 @@ class WaveResource(Resource):
         logger.info("WaveResource: {}".format(self.filename))
 
     def download_resource(self):
-        #TODO: Add ability to use MHKit for resource downloads
-        # https://mhkit-software.github.io/MHKiT/
+        """
+        Placeholder for downloading wave resource data.
+
+        Raises:
+            NotImplementedError: Currently, downloading functionality is not implemented.
+        
+        TODO:
+            Implement resource downloads using MHKit: 
+            https://mhkit-software.github.io/MHKiT/
+        """
         raise NotImplementedError
 
     def format_data(self):
         """
-        Format as 'wave_resource_data' dictionary for use in PySAM.
+        Formats wave resource data as a dictionary for PySAM.
+
+        Raises:
+            FileNotFoundError: If the specified resource file does not exist.
         """
         if not os.path.isfile(self.filename):
             raise FileNotFoundError(self.filename + " does not exist.")
@@ -66,14 +88,25 @@ class WaveResource(Resource):
     @Resource.data.setter
     def data(self, data_file):
         """
-        Sets the wave resource data to a dictionary in the SAM Wave format:
-            - significant_wave_height: wave height time series data [m]
-            - energy period: wave period time series data [s]
-            - year
-            - month
-            - day
-            - hour
-            - minute
+        Sets the wave resource data in PySAM's wave energy format.
+
+        Args:
+            data_file (str): File path to the wave resource data.
+
+        Raises:
+            ValueError: If the resource time series contains sub-hourly data.
+
+        The output dictionary includes:
+            - `significant_wave_height` (list[float]): Wave height time series data [m].
+            - `energy_period` (list[float]): Wave period time series data [s].
+            - `year` (list[int]): Year timestamps.
+            - `month` (list[int]): Month timestamps.
+            - `day` (list[int]): Day timestamps.
+            - `hour` (list[int]): Hour timestamps.
+            - `minute` (list[int]): Minute timestamps.
+
+        If the time series is incomplete (less than 8760 hours), the function 
+        linearly interpolates missing values to create a complete hourly dataset.
         """
         wavefile_model = wavefile.new()
         #Load resource file

--- a/hopp/simulation/technologies/resource/wave_resource.py
+++ b/hopp/simulation/technologies/resource/wave_resource.py
@@ -35,12 +35,12 @@ class WaveResource(Resource):
 
         Notes:
             The wave resource data should be in the format:
-            - Rows 1 and 2: Header rows with location info.
-            - Row 3: Column headings for time-series data 
-              (`month`, `day`, `hour`, `minute`, `wave height`, `wave period`).
-            - Rows 4+: Data values:
-              - `wave height` (significant wave height) in meters.
-              - `wave period` (energy period) in seconds.
+                - Rows 1 and 2: Header rows with location info.
+                - Row 3: Column headings for time-series data 
+                (`Year`, `Month`, `Day`, `Hour`, `Minute`, `wave height`, `wave period`).
+                - Rows 4+: Data values:
+                - `wave height` (significant wave height) in meters.
+                - `wave period` (energy period) in seconds.
 
             Example file: 
             `hopp/simulation/resource_files/wave/Wave_resource_timeseries.csv`


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Wave Resource Deprecated Methods

<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
Update two Pandas methods that are deprecated and will raise errors in future:

- `fillna(ffill)` to `ffill()`
- "H" to "h"

Update docstrings to Google format.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `RELEASE.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [x] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->


## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `hopp/simulation/technologies/resource/wave_resource.py`
  - `resample()`: "H" is deprecated used "h" instead.
  - `df.fillna(ffill)`: Method is deprecated updated to `df.ffill()`.

## Additional supporting information

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in hopp/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/HOPP repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
