### PR TITLE
Update wind tests for floats

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+* Loosened strictness of comparison for wind turbine config checking
+
 ## Version 3.2.0, March 21, 2025
 
 * Updates related to PySAM:

--- a/hopp/simulation/technologies/financial/custom_financial_model.py
+++ b/hopp/simulation/technologies/financial/custom_financial_model.py
@@ -184,7 +184,7 @@ class CustomFinancialModel():
     """
     This custom financial model slots into the PowerSource's financial model that is originally a
     PySAM.Singleowner model. PowerSource and the overlaying classes that call on PowerSource expect
-    properties and functions from the financial model. The mininum expectations are listed here as
+    properties and functions from the financial model. The minimum expectations are listed here as
     the class interface.
     
     The financial model is constructed with financial configuration inputs. During simulation, the

--- a/hopp/simulation/technologies/power_source.py
+++ b/hopp/simulation/technologies/power_source.py
@@ -49,10 +49,6 @@ class PowerSource(BaseClass):
         if isinstance(self._financial_model, Singleowner.Singleowner):
             self.initialize_financial_values()
         else:
-            if inspect.ismethod(getattr(self._system_model, 'export', None)):
-                self._financial_model.assign(self._system_model.export(), ignore_missing_vals=True)       # copy system parameter values having same name
-            else:
-                pass
             self._financial_model.set_financial_inputs(system_model=self._system_model)               # for custom financial models
 
         self.capacity_factor_mode = "cap_hours"                                    # to calculate via "cap_hours" method or None to use external value

--- a/hopp/simulation/technologies/wind/floris.py
+++ b/hopp/simulation/technologies/wind/floris.py
@@ -132,7 +132,7 @@ class Floris(BaseClass):
         self.turb_rating = max(self.wind_turbine_powercurve_powerout)
         
         if self.config.turbine_rating_kw is not None:
-            if self.config.turbine_rating_kw != self.turb_rating:
+            if not np.isclose(self.config.turbine_rating_kw, self.turb_rating, atol=1e-3):
                 msg = (
                     f"Input turbine rating ({self.config.turbine_rating_kw} kW) does not match "
                     f"rating from floris power-curve ({self.turb_rating} kW). "
@@ -141,7 +141,7 @@ class Floris(BaseClass):
                 )
                 raise ValueError(msg)
         if self.config.rotor_diameter is not None:
-            if self.config.rotor_diameter != self.wind_turbine_rotor_diameter:
+            if not np.isclose(self.config.rotor_diameter, self.wind_turbine_rotor_diameter, atol=1e-4):
                 msg = (
                     f"Input rotor diameter ({self.config.rotor_diameter}) does not match "
                     f"rotor diameter from floris config ({self.wind_turbine_rotor_diameter}). "
@@ -150,7 +150,7 @@ class Floris(BaseClass):
                 )
                 raise ValueError(msg)
         if self.config.hub_height is not None:
-            if self.config.hub_height != hub_height:
+            if not np.isclose(self.config.hub_height, hub_height, atol=1e-4):
                 msg = (
                     f"Input hub-height ({self.config.hub_height}) does not match "
                     f"hub-height from floris config ({hub_height}). "
@@ -159,6 +159,7 @@ class Floris(BaseClass):
                     f"or correct the value to {hub_height}."
                 )
                 raise ValueError(msg)
+
         if hub_height != self.site.wind_resource.hub_height_meters:
             valid_min_height = hub_height >= min(self.site.wind_resource.data["heights"])
             valid_max_height = hub_height <= max(self.site.wind_resource.data["heights"])

--- a/hopp/simulation/technologies/wind/floris.py
+++ b/hopp/simulation/technologies/wind/floris.py
@@ -41,7 +41,7 @@ class Floris(BaseClass):
     
     #results
     gen: list[float] = field(init = False)
-    annual_energy: float = field(default=0.)
+    annual_energy: float = field(init = False)
     capacity_factor: float = field(init = False)
     annual_energy_pre_curtailment_ac: float = field(init = False)
     
@@ -281,7 +281,6 @@ class Floris(BaseClass):
         """
         config = {
             'system_capacity': self.system_capacity,
-            'annual_energy': self.annual_energy,
         }
         return config
     

--- a/hopp/simulation/technologies/wind/floris.py
+++ b/hopp/simulation/technologies/wind/floris.py
@@ -41,7 +41,7 @@ class Floris(BaseClass):
     
     #results
     gen: list[float] = field(init = False)
-    annual_energy: float = field(init = False)
+    annual_energy: float = field(default=0.)
     capacity_factor: float = field(init = False)
     annual_energy_pre_curtailment_ac: float = field(init = False)
     
@@ -98,15 +98,15 @@ class Floris(BaseClass):
         
 
     def initialize_from_floris(self, floris_config):
-        """Initialize wind turbine parmeters and set in floris_config.
+        """Initialize wind turbine parameters and set in floris_config.
 
         Args:
             floris_config (dict): floris input dictionary
 
         Raises:
-            ValueError: if rotor_diameter in WindConfig doesnt match rotor diameter in floris_config
-            ValueError: if turbine_rating_kw in WindConfig doesnt match turbine rating from power-curve
-            ValueError: if hub_height in WindConfig doesnt match hub-height in floris_config
+            ValueError: if rotor_diameter in WindConfig doesn't match rotor diameter in floris_config
+            ValueError: if turbine_rating_kw in WindConfig doesn't match turbine rating from power-curve
+            ValueError: if hub_height in WindConfig doesn't match hub-height in floris_config
 
 
         Returns:


### PR DESCRIPTION
# Update wind tests for floats

We recently added some nice checks for inputs.
Sometimes they're comparing floats which might differ in the 9th digit in a non-meaningful way, resulting in errors like this:

```
ValueError: Input turbine rating (6000 kW) does not match rating from floris power-curve (6000.000053387264 kW)
```

This PR loosens those comparisons so they're more forgiving for float values.
Also fixes some logic that assumed `annual_energy` existed when it didn't necessarily at that point.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `RELEASE.md` has been updated to describe the changes made in this PR
- [-] Documentation
  - [-] Docstrings are up-to-date
  - [-] Related `docs/` files are up-to-date, or added when necessary
  - [-] Documentation has been rebuilt successfully
  - [-] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

N/A


## Impacted areas of the software

N/A

## Additional supporting information
N/A


## Test results, if applicable

N/A