### PR TITLE
Loosen turbine rating check

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Loosened strictness of comparison for wind turbine config checking
+* Loosened strictness of comparison for wind turbine config checking and added tests
 
 ## Version 3.2.0, March 21, 2025
 

--- a/hopp/simulation/technologies/wind/floris.py
+++ b/hopp/simulation/technologies/wind/floris.py
@@ -132,7 +132,7 @@ class Floris(BaseClass):
         self.turb_rating = max(self.wind_turbine_powercurve_powerout)
         
         if self.config.turbine_rating_kw is not None:
-            if not np.isclose(self.config.turbine_rating_kw, self.turb_rating, atol=1e-3):
+            if not np.isclose(self.config.turbine_rating_kw, self.turb_rating, rtol=0.1):
                 msg = (
                     f"Input turbine rating ({self.config.turbine_rating_kw} kW) does not match "
                     f"rating from floris power-curve ({self.turb_rating} kW). "

--- a/tests/hopp/test_turbine_models_interface.py
+++ b/tests/hopp/test_turbine_models_interface.py
@@ -143,6 +143,63 @@ def test_floris_NREL_5MW_RWT_corrected_hopp(site_input,subtests):
     with subtests.test("wind capacity factor"):
         assert hybrid_plant.capacity_factors["wind"] == approx(42.0, abs = 1.0)
 
+def test_floris_NREL_5MW_RWT_error_hopp(site_input, subtests):
+    floris_template = load_yaml(str(FLORIS_V4_TEMPLATE_PATH))
+    turbine_library_turbine_name = "NREL_Reference_5MW_126"
+    n_turbs = 4
+    turbine_rating_kw = 6000.0
+    layout_x = [0.0, 1841.0, 3682.0, 5523.0]
+    layout_y = [0.0] * n_turbs
+    floris_template["farm"].update({"layout_x": layout_x, "layout_y": layout_y})
+    wind_config_dict = {
+        "num_turbines": n_turbs,
+        "turbine_rating_kw": turbine_rating_kw,
+        "turbine_name": turbine_library_turbine_name,
+        "model_name": "floris",
+        "floris_config": floris_template,
+        "layout_mode": "floris_layout"
+    }
+    site_input.update({"hub_height": 90.0})
+    system_capacity_kw = turbine_rating_kw * n_turbs
+    technologies = {"wind": wind_config_dict, "grid": {"interconnect_kw": system_capacity_kw}}
+    hybrid_config = {"site": site_input, "technologies": technologies}
+    
+    with subtests.test("error on invalid turbine rating"):
+        with pytest.raises(ValueError):
+            hi = HoppInterface(hybrid_config)
+            hi.simulate(25)
+
+def test_floris_NREL_5MW_RWT_no_error_hopp(site_input, subtests):
+    floris_template = load_yaml(str(FLORIS_V4_TEMPLATE_PATH))
+    turbine_library_turbine_name = "NREL_Reference_5MW_126"
+    n_turbs = 4
+    turbine_rating_kw = 4900.0
+    layout_x = [0.0, 1841.0, 3682.0, 5523.0]
+    layout_y = [0.0] * n_turbs
+    floris_template["farm"].update({"layout_x": layout_x, "layout_y": layout_y})
+    wind_config_dict = {
+        "num_turbines": n_turbs,
+        "turbine_rating_kw": turbine_rating_kw,
+        "turbine_name": turbine_library_turbine_name,
+        "model_name": "floris",
+        "floris_config": floris_template,
+        "layout_mode": "floris_layout"
+    }
+    site_input.update({"hub_height": 90.0})
+    system_capacity_kw = turbine_rating_kw * n_turbs
+    technologies = {"wind": wind_config_dict, "grid": {"interconnect_kw": system_capacity_kw}}
+    hybrid_config = {"site": site_input, "technologies": technologies}
+    
+    hi = HoppInterface(hybrid_config)
+    hybrid_plant = hi.system
+
+    hi.simulate(25)
+
+    aeps = hybrid_plant.annual_energies
+    with subtests.test("wind aep"):
+        assert aeps.wind == approx(74149945, 1e-3)
+    with subtests.test("wind capacity factor"):
+        assert hybrid_plant.capacity_factors["wind"] == approx(43.2, abs = 1.0)
 
 
 def test_pysam_NREL_5MW_RWT_corrected_hopp(site_input,subtests):


### PR DESCRIPTION
# Loosen turbine rating check

Sometimes turbines operate above their rated power for a bit.
This PR loosens the restriction that the rated power must match the max from the power curve, allowing for this behavior.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `RELEASE.md` has been updated to describe the changes made in this PR
- [-] Documentation
  - [-] Docstrings are up-to-date
  - [-] Related `docs/` files are up-to-date, or added when necessary
  - [-] Documentation has been rebuilt successfully
  - [-] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->


## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `path/to/file.extension`
  - `method1`: What and why something was changed in one sentence or less.

## Additional supporting information

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in hopp/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/HOPP repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
