### PR TITLE
GREET data additions for usa_iron PR, Updated asserts to correct failing tests in test_cost_calculator.py

### DIFF
--- a/hopp/simulation/resource_files/greet/2023/greet_2023_processed.yaml
+++ b/hopp/simulation/resource_files/greet/2023/greet_2023_processed.yaml
@@ -18,6 +18,7 @@ atr_electricity_consume: 3.561733081975984
 battery_LFP_EI: 20
 bio_capex_EI: 0.8023917580032691
 coal_capex_EI: 0.7870905519183622
+coke_supply_EI: 0.39783475314651884
 desal_H2O_supply_EI: 0.010889
 gas_capex_EI: 0.41713301095483096
 geothermal_binary_capex_EI: 20.43919040434449

--- a/hopp/simulation/technologies/resource/greet_data.py
+++ b/hopp/simulation/technologies/resource/greet_data.py
@@ -149,11 +149,11 @@ class GREETData:
         geothermal_flash_capex_EI = (greet1['ElecInfra']['J112'].value / mmbtu_to_kWh)              # Geothermal Flash CAPEX emissions (g CO2e/kWh)
         geothermal_binary_capex_EI = (greet1['ElecInfra']['K112'].value / mmbtu_to_kWh)             # Geothermal Binary CAPEX emissions (g CO2e/kWh)
         # Lime
-        lime_supply_EI = ((greet1['Chemicals']['BA247'].value +                                     # GHG Emissions Intensity of supplying Lime to processes accounting for limestone mining, lime production, lime processing, and lime transportation assuming 20 miles transport via Diesel engines (kg CO2e/kg lime)
-                         (greet1['Chemicals']['BA237'].value * VOC_to_CO2e) +             
-                         (greet1['Chemicals']['BA238'].value * CO_to_CO2e) +
-                         (greet1['Chemicals']['BA245'].value * CH4_gwp_to_CO2e) +
-                         (greet1['Chemicals']['BA246'].value * N2O_gwp_to_CO2e)
+        lime_supply_EI = ((greet1['Ag_Inputs']['BN121'].value +                                     # GHG Emissions Intensity of supplying Lime to processes accounting for limestone mining, lime production, lime processing, and lime transportation assuming 20 miles transport via Diesel engines (kg CO2e/kg lime)
+                         (greet1['Ag_Inputs']['BN111'].value * VOC_to_CO2e) +
+                         (greet1['Ag_Inputs']['BN112'].value * CO_to_CO2e) +
+                         (greet1['Ag_Inputs']['BN119'].value * CH4_gwp_to_CO2e) +
+                         (greet1['Ag_Inputs']['BN120'].value * N2O_gwp_to_CO2e)
                          ) * g_to_kg * (1/ton_to_kg))
         # Natural Gas (NG)
         NG_combust_EI = ((greet1['EF']['B16'].value +                                               # GHG Emissions Intensity of Natural Gas combustion in a utility / industrial large boiler (g CO2e/MJ Natural Gas combusted)
@@ -188,6 +188,14 @@ class GREETData:
         alk_ely_stack_and_BoP_capex_EI = (greet2['Electrolyzers']['R257'].value * g_to_kg)          # Alkaline electrolyzer stack + Balance of Plant CAPEX  emissions (kg CO2e/kg H2)
         soec_ely_stack_capex_EI = (greet2['Electrolyzers']['C257'].value * g_to_kg)                 # SOEC electrolyzer stack CAPEX emissions (kg CO2e/kg H2)
         soec_ely_stack_and_BoP_capex_EI = (greet2['Electrolyzers']['F257'].value * g_to_kg)         # SOEC electrolyzer stack + Balance of Plant CAPEX emissions (kg CO2e/kg H2)
+        # Carbon Coke
+        coke_supply_EI = ((greet2['Steel']['B125'].value +
+                          (greet2['Steel']['B115'].value * VOC_to_CO2e) +
+                          (greet2['Steel']['B116'].value * CO_to_CO2e) +
+                          (greet2['Steel']['B123'].value * CH4_gwp_to_CO2e) +
+                          (greet2['Steel']['B124'].value * N2O_gwp_to_CO2e)
+                          ) * (g_to_kg/ton_to_kg))                                                  # GHG Emissions Intensity of supplying Coke to processes accounting for combustion and non-combustion emissions of coke production (kg CO2e/kg Coke)
+                                                                                                    # Does not account for mining of coal or transportation
         # Steel
         steel_H2O_consume = ((greet2['Steel']['AE80'].value +                                       # Total H2O consumption for DRI-EAF Steel production w/ 83% H2 and 0% scrap, accounts for water used in iron ore mining, pelletizing, DRI, and EAF (metric tonne H2O/metric tonne steel production)
                               greet2['Steel']['AG80'].value +                                       # NOTE: Does not include water consumption for H2 production via electrolysis
@@ -206,7 +214,7 @@ class GREETData:
         steel_electricity_consume = ((greet2['Steel']['AK65'].value +                               # Total Electrical Energy consumption for DRI-EAF Steel production accounting for DRI with 83% H2 and EAF + LRF (MWh/metric tonne steel production)
                                       greet2['Steel']['AM65'].value
                                      ) * (mmbtu_to_MWh/ton_to_MT))
-        #Iron
+        # Iron
         DRI_iron_ore_mining_EI_per_MT_steel = ((greet2['Steel']['AE92'].value +                     # GHG Emissions Intensity of Iron ore mining for use in DRI-EAF Steel production (kg CO2e/metric tonne steel production)
                                                (greet2['Steel']['AE82'].value * VOC_to_CO2e) +                     
                                                (greet2['Steel']['AE83'].value * CO_to_CO2e) +
@@ -273,6 +281,8 @@ class GREETData:
                      'NG_supply_EI':NG_supply_EI,
                      # Lime
                      'lime_supply_EI':lime_supply_EI,
+                     # Coke
+                     'coke_supply_EI':coke_supply_EI,
                      # Iron ore
                      'DRI_iron_ore_mining_EI_per_MT_steel':DRI_iron_ore_mining_EI_per_MT_steel,
                      'DRI_iron_ore_pelletizing_EI_per_MT_steel':DRI_iron_ore_pelletizing_EI_per_MT_steel,

--- a/tests/hopp/test_cost_calculator.py
+++ b/tests/hopp/test_cost_calculator.py
@@ -100,7 +100,9 @@ class TestCostCalculator:
 
         assert wind_bos_cost > low_wind_bos
         assert wind_bos_cost < high_wind_bos
-        assert solar_bos_cost == low_solar_bos_cost == high_solar_bos_cost
+        assert solar_bos_cost == pytest.approx(low_solar_bos_cost)
+        assert solar_bos_cost == pytest.approx(high_solar_bos_cost)
+        assert low_solar_bos_cost == pytest.approx(high_solar_bos_cost)
         assert total_bos_cost == pytest.approx(75356239)
         assert min_distance != 0
 


### PR DESCRIPTION
# GREET data additions for usa_iron PR, Updated asserts to correct failing tests in test_cost_calculator.py

Added in additional code to pull coke_supply_EI value from GREET 2023 data and save in processed.yaml. Updated assertion in test_cost_calculator.py to assert X == pytest.approx(Y), prior failure of test due to floating point precision


## PR Checklist

- [ ] `RELEASE.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

GreenHEART PR 90: https://github.com/NREL/GreenHEART/pull/90


## Impacted areas of the software

additional lines of code in greet_data.py and updated assert statements in test_cost_calculator.py

## Additional supporting information

update needed for accurate LCA calculations of coke and lime consumption for Iron Electrowinning project


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in hopp/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/HOPP repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
