### PR TITLE
Bump python version max

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "NREL", email = "dguittet@nrel.gov"}]
 readme = {file = "README.md", content-type = "text/markdown"}
 description = "Hybrid Systems Optimization and Performance Platform."
-requires-python = ">=3.10, <3.12"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 dependencies = [
     "Cython",


### PR DESCRIPTION
# Bump python version max

PySAM 4.2 was limited to Python < 3.12, but now that we're on PySAM 7.0 let's loosen up the max Python limit.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [-] `RELEASE.md` has been updated to describe the changes made in this PR
- [-] Documentation
  - [-] Docstrings are up-to-date
  - [-] Related `docs/` files are up-to-date, or added when necessary
  - [-] Documentation has been rebuilt successfully
  - [-] Examples have been updated
- [-] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [-] PR description thoroughly describes the new feature, bug fix, etc.
