### PR TITLE
Bumping Python version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -49,7 +49,7 @@ the problem. All code and full tracebacks should be properly markdown formatted.
 <!-- Add your information here. -->
 - OS: <macOS 12.4>
   <!-- e.g. Ubuntu 20.04 or macOS 10.12 -->
-- Python version: <3.10.4>
+- Python version: <3.11.1>
   <!-- All OS: `python --version`-->
 - HOPP version: <0.1.1>
   <!--
@@ -66,7 +66,7 @@ the problem. All code and full tracebacks should be properly markdown formatted.
 ### Relevant library versions
 <!--
 Use `pip freeze` to gather the relevant versions, and use the markdown table formatting as
-demonstrated below to replacing all relavant packages and their versions.
+demonstrated below to replacing all relevant packages and their versions.
 -->
   
   | Package | Version |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ HOPP is primarily developed with the support of the U.S. Department of Energy an
 
 ## Software requirements
 
-- Python version 3.10, and 3.11 only
+- Python version 3.11 or higher
 
 ## Installing from Package Repositories
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "NREL", email = "dguittet@nrel.gov"}]
 readme = {file = "README.md", content-type = "text/markdown"}
 description = "Hybrid Systems Optimization and Performance Platform."
-requires-python = ">=3.10, <3.12"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 dependencies = [
     "Cython",
@@ -69,8 +69,10 @@ classifiers = [  # https://pypi.org/classifiers/
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ classifiers = [  # https://pypi.org/classifiers/
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/tests/hopp/test_hybrid.py
+++ b/tests/hopp/test_hybrid.py
@@ -777,7 +777,7 @@ def test_hybrid_pv_only_custom_fin(hybrid_config, subtests):
 
     with subtests.test("aep"):
         assert aeps.pv == approx(10789795.03, 1e-3)
-        assert aeps.hybrid == aeps.pv
+        assert aeps.hybrid == approx(aeps.pv)
 
 
 def test_hybrid_pv_battery_custom_fin(hybrid_config, subtests):


### PR DESCRIPTION
# Bumping Python version

Increasing min Python version to 3.11 and allowing 3.12, 3.13, 3.14.


## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [ ] `RELEASE.md` has been updated to describe the changes made in this PR
- [ ] Documentation
  - [ ] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated
- [ ] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [ ] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->


## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `path/to/file.extension`
  - `method1`: What and why something was changed in one sentence or less.

## Additional supporting information

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in hopp/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/HOPP repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
