### PR TITLE
Fix: Flatten (N, 1) arrays to (N,) for NumPy/Ctypes updates

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 * Add load following heuristic dispatch test
 * Consolidated utilities, renamed MHKConfig to MHKWaveConfig
 * Updated solar resource download to use GOES Aggregated PSM v4 download
+* Fix a bug caused by arrays with shape (N, 1) being passed to a `c_double` array with shape (N,)
 
 ## Version 3.3.0, April 30, 2025
 

--- a/hopp/simulation/technologies/csp/pySSC_daotk/ssc_wrap.py
+++ b/hopp/simulation/technologies/csp/pySSC_daotk/ssc_wrap.py
@@ -486,7 +486,7 @@ class PySSC:
     def data_set_array(self, p_data, name, parr):
         count = len(parr)
         arr = (c_number * count)()
-        arr[:] = parr  # set all at once instead of looping
+        arr[:] = parr.flatten()  # set all at once instead of looping
         return self.pdll.ssc_data_set_array(c_void_p(p_data), c_char_p(name), pointer(arr), c_int(count))
 
     def data_set_array_from_csv(self, p_data, name, fn):

--- a/hopp/simulation/technologies/csp/pySSC_daotk/ssc_wrap.py
+++ b/hopp/simulation/technologies/csp/pySSC_daotk/ssc_wrap.py
@@ -6,6 +6,8 @@ import abc
 import importlib
 import copy
 
+import numpy as np
+
 PYSAM_MODULE_NAME = 'PySAM_DAOTk'
 # PYSAM_MODULE_NAME = 'PySAM'
 SSCDLL_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "libs", "ssc.dll")
@@ -486,6 +488,8 @@ class PySSC:
     def data_set_array(self, p_data, name, parr):
         count = len(parr)
         arr = (c_number * count)()
+        if not isinstance(parr, np.ndarray):
+            parr = np.array(parr)
         arr[:] = parr.flatten()  # set all at once instead of looping
         return self.pdll.ssc_data_set_array(c_void_p(p_data), c_char_p(name), pointer(arr), c_int(count))
 

--- a/hopp/simulation/technologies/pySSC_daotk/ssc_wrap.py
+++ b/hopp/simulation/technologies/pySSC_daotk/ssc_wrap.py
@@ -486,7 +486,7 @@ class PySSC:
     def data_set_array(self, p_data, name, parr):
         count = len(parr)
         arr = (c_number * count)()
-        arr[:] = parr  # set all at once instead of looping
+        arr[:] = parr.flatten()  # set all at once instead of looping
         return self.pdll.ssc_data_set_array(c_void_p(p_data), c_char_p(name), pointer(arr), c_int(count))
 
     def data_set_array_from_csv(self, p_data, name, fn):

--- a/hopp/simulation/technologies/pySSC_daotk/ssc_wrap.py
+++ b/hopp/simulation/technologies/pySSC_daotk/ssc_wrap.py
@@ -6,6 +6,8 @@ import abc
 import importlib
 import copy
 
+import numpy as np
+
 PYSAM_MODULE_NAME = 'PySAM_DAOTk'
 # PYSAM_MODULE_NAME = 'PySAM'
 SSCDLL_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "libs", "ssc.dll")
@@ -486,6 +488,8 @@ class PySSC:
     def data_set_array(self, p_data, name, parr):
         count = len(parr)
         arr = (c_number * count)()
+        if not isinstance(parr, np.ndarray):
+            parr = np.array(parr)
         arr[:] = parr.flatten()  # set all at once instead of looping
         return self.pdll.ssc_data_set_array(c_void_p(p_data), c_char_p(name), pointer(arr), c_int(count))
 


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELTE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code higlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Flatten matrix-shaped arrays to 1D arrays for `c_double` casting

<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
This PR is addressing the test failures cropping up in #509 caused by passing a (N, 1) NumPy array to a (N,) `c_double` array. By reshaping the NumPy arrays to shape (N,) the issue is resolved.

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `RELEASE.md` has been updated to describe the changes made in this PR
- [ ] Documentation
  - [ ] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->
N/A, this is a brand new issue blocking a PR.

## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `hopp/simulation/technologies/pySSC_daotk/ssc_wrap.py`
  - `PySSC.data_set_array`: reshapes the passed NumPy array from (N, 1) to (N).
- `hopp/simulation/technologies/csp/pySSC_daotk/ssc_wrap.py`
  - `PySSC.data_set_array`: reshapes the passed NumPy array from (N, 1) to (N).

## Additional supporting information

<!--Add any other context about the problem here.-->
All test failures were due to this line of code in `hopp/simulation/technologies/pySSC_daotk/ssc_wrap.py::PySSC.data_set_array`

<img width="630" height="120" alt="image" src="https://github.com/user-attachments/assets/ded8bb3c-8890-41a6-adb5-eb5f6fc2b437" />


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in hopp/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/HOPP repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
