### PR TITLE
Release 3.4.2

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 3.4.2, unreleased
+
+* Unpinned `fastkml` version to remove package dependency issues
+
 ## Version 3.4.1, January 28, 2026
 
 * Pin Jupyter Book to 1.x until v2 migration.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Version 3.4.2, unreleased
+## Version 3.4.2, February 9, 2026
 
 * Unpinned `fastkml` version to remove package dependency issues
 

--- a/hopp/__init__.py
+++ b/hopp/__init__.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-__version__ = "3.4.1"
+__version__ = "3.4.2"
 
 ROOT_DIR = Path(__file__).resolve().parent
 

--- a/hopp/simulation/technologies/sites/site_info.py
+++ b/hopp/simulation/technologies/sites/site_info.py
@@ -500,11 +500,9 @@ class SiteInfo(BaseClass):
 
     @staticmethod
     def kml_read(filepath):
-        k = kml.KML()
-        with open(filepath) as kml_file:
-            k.from_string(kml_file.read().encode("utf-8"))
-        features = list(k.features())[0]
-        placemarks = list(list(features.features())[0].features())
+        k = kml.KML.parse(filepath)
+        features = k.features[0]
+        placemarks = features.features[0].features
         
         gmaps_epsg = pyproj.CRS("EPSG:4326")
         project = None
@@ -533,7 +531,6 @@ class SiteInfo(BaseClass):
 
     @staticmethod
     def append_kml_data(kml_data, polygon, name):
-        folder = kml_data._features[0]._features[0]
-        new_pm = kml.Placemark(name=name)
-        new_pm.geometry = polygon
+        folder = kml_data.features[0].features[0]
+        new_pm = kml.Placemark(name=name, geometry=polygon)
         folder.append(new_pm)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "NREL-PySAM>=7.0.0",
     "Pillow",
     "Pyomo>=6.1.2",
-    "fastkml<1",
+    "fastkml",
     "floris==4.3",
     "future",
     "global_land_mask",


### PR DESCRIPTION
Patch release to remove pinning `fastkml<1`, and allow all releases.
